### PR TITLE
fix(index): load twbs scripts (for responsive header)

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <script src="config.js"></script>
     <script>
       System.baseUrl = 'dist'; //NOTE: You can move this into the config.js file, if you like.
+      System.import('bootstrap').catch(console.error.bind(console));
       System.import('aurelia-bootstrapper').catch(console.error.bind(console));
     </script>
   </body>


### PR DESCRIPTION
The `navbar-toggle` button is broken without the bootstrap.js (note: the button is only shown when screen has a small width).