### PR TITLE
postinstall jspm dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To run the app, follow these steps.
   npm install -g jspm
   ```
   > **Note:** jspm queries GitHub to install semver packages, but GitHub has a rate limit on anonymous API requests. It is advised that you configure jspm with your GitHub credentials in order to avoid problems. You can do this by executing `jspm endpoint config github` and following the prompts.
+  
   >**Note:** Windows users, if you experience an error of "unknown command unzip" you can solve this problem by doing `npm install -g unzip` and then re-running `jspm install`.
 5. To run the app, execute the following command:
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To run the app, follow these steps.
   ```shell
   npm install
   ```
+  >**Note:** this installs jspm dependencies too by running ```javascript jspm install ``` as postinstall command
 3. Ensure that [Gulp](http://gulpjs.com/) is installed. If you need to install it, use the following command:
 
   ```shell
@@ -25,18 +26,13 @@ To run the app, follow these steps.
   npm install -g jspm
   ```
   > **Note:** jspm queries GitHub to install semver packages, but GitHub has a rate limit on anonymous API requests. It is advised that you configure jspm with your GitHub credentials in order to avoid problems. You can do this by executing `jspm endpoint config github` and following the prompts.
-5. Install the client-side dependencies with jspm:
-
-  ```shell
-  jspm install
-  ```
   >**Note:** Windows users, if you experience an error of "unknown command unzip" you can solve this problem by doing `npm install -g unzip` and then re-running `jspm install`.
-6. To run the app, execute the following command:
+5. To run the app, execute the following command:
 
   ```shell
   gulp watch
   ```
-7. Browse to [http://localhost:9000](http://localhost:9000) to see the app. You can make changes in the code found under `src` and the browser should auto-refresh itself as you save files.
+6. Browse to [http://localhost:9000](http://localhost:9000) to see the app. You can make changes in the code found under `src` and the browser should auto-refresh itself as you save files.
 
 > Note: At present there is a bug in the HTMLImports polyfill which only occurs on IE. We have submitted a pull request to the team with the fix. In the mean time, if you want to test on IE, you can work around the issue by explicitly adding a script tag before you load system.js. The script tag should look something like this (be sure to confirm the version number):
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To run the app, follow these steps.
   ```shell
   npm install
   ```
-  >**Note:** this installs jspm dependencies too by running ```javascript jspm install ``` as postinstall command
+  >**Note:** this installs jspm dependencies too by running ``` jspm install ``` as postinstall command
 3. Ensure that [Gulp](http://gulpjs.com/) is installed. If you need to install it, use the following command:
 
   ```shell

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" type="text/css" href="jspm_packages/npm/font-awesome@4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" type="text/css" href="styles/styles.css">
   </head>
-  <body aurelia-app>
+  <body aurelia-app="app">
     <div class="splash">
       <div class="message">Aurelia Navigation Skeleton</div>
       <i class="fa fa-spinner fa-spin"></i>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "http://github.com/aurelia/skeleton-navigation"
   },
+  "scripts": {
+    "postinstall": "jspm install -y"
+  },
   "devDependencies": {
     "aurelia-tools": "git://github.com/aurelia/tools.git",
     "browser-sync": "^1.8.1",


### PR DESCRIPTION
saves people typing that one extra command
and specify the value for aurelia-app attribute so that the skeleton is more explicit