### PR TITLE
fix(build): include root attribute on path for source maps

### DIFF
--- a/build/paths.js
+++ b/build/paths.js
@@ -1,10 +1,13 @@
 var path = require('path');
 
+var appRoot = 'src/';
+
 module.exports = {
-  source:'src/**/*.js',
-  html:'src/**/*.html',
-  style:'styles/**/*.css',
-  output:'dist/',
+  root: appRoot,
+  source: appRoot + '**/*.js',
+  html: appRoot + '**/*.html',
+  style: 'styles/**/*.css',
+  output: 'dist/',
   doc:'./doc',
   e2eSpecsSrc: 'test/e2e/src/*.js',
   e2eSpecsDist: 'test/e2e/dist/'

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -14,7 +14,7 @@ gulp.task('build-system', function () {
     .pipe(changed(paths.output, {extension: '.js'}))
     .pipe(sourcemaps.init())
     .pipe(to5(assign({}, compilerOptions, {modules:'system'})))
-    .pipe(sourcemaps.write({includeContent: false, sourceRoot: '/src'}))
+    .pipe(sourcemaps.write({includeContent: false, sourceRoot: '/' + paths.root }))
     .pipe(gulp.dest(paths.output));
 });
 


### PR DESCRIPTION
Currently, the build task statically uses the 'src/' folder to output source maps. We have added an additional parameter to the paths object in the gulp task, called root, which is used for generating source maps and for prefixing the source and html attributes.

closes 26