### PR TITLE
feat(build): Utilise in-built 6to5 support in SystemJS

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,10 +1,12 @@
 System.config({
+  "transpiler": "6to5",
   "paths": {
     "*": "*.js",
     "github:*": "jspm_packages/github/*.js",
     "npm:*": "jspm_packages/npm/*.js",
     "aurelia-skeleton-navigation/*": "lib/*.js"
-  }
+  },
+  "baseUrl": "src"
 });
 
 System.config({

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
     <script src="jspm_packages/system.js"></script>
     <script src="config.js"></script>
     <script>
-      System.baseUrl = 'dist'; //NOTE: You can move this into the config.js file, if you like.
       System.import('aurelia-bootstrapper');
     </script>
   </body>


### PR DESCRIPTION
Instead of utilising the `watch` task to fire off the associated `build-html` and `build-system` tasks, utilise JSPM `0.11.0`'s built-in [6to5 transpiler support](https://github.com/systemjs/systemjs/issues/232), which will do it automagically for us.