### PR TITLE
fix(build): use relative path for source maps. resolve #66

### DIFF
--- a/build/paths.js
+++ b/build/paths.js
@@ -1,13 +1,15 @@
 var path = require('path');
 
 var appRoot = 'src/';
+var outputRoot = 'dist/';
 
 module.exports = {
   root: appRoot,
   source: appRoot + '**/*.js',
   html: appRoot + '**/*.html',
   style: 'styles/**/*.css',
-  output: 'dist/',
+  output: outputRoot,
+  sourceMapRelativePath: '../' + appRoot,
   doc:'./doc',
   e2eSpecsSrc: 'test/e2e/src/*.js',
   e2eSpecsDist: 'test/e2e/dist/'

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -16,9 +16,9 @@ gulp.task('build-system', function () {
   return gulp.src(paths.source)
     .pipe(plumber())
     .pipe(changed(paths.output, {extension: '.js'}))
-    .pipe(sourcemaps.init())
+    .pipe(sourcemaps.init({loadMaps: true}))
     .pipe(to5(assign({}, compilerOptions, {modules:'system'})))
-    .pipe(sourcemaps.write({includeContent: false, sourceRoot: '/' + paths.root }))
+    .pipe(sourcemaps.write({includeContent: false, sourceRoot: paths.sourceMapRelativePath }))
     .pipe(gulp.dest(paths.output));
 });
 


### PR DESCRIPTION
This is based on conversations had yesterday in the gitter channel.