### PR TITLE
fix(navbar): automatically collapse the navigation menu on click

### DIFF
--- a/src/nav-bar.html
+++ b/src/nav-bar.html
@@ -16,7 +16,7 @@
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
         <li repeat.for="row of router.navigation" class="${row.isActive ? 'active' : ''}">
-          <a href.bind="row.href">${row.title}</a>
+          <a data-toggle="collapse" data-target="#bs-example-navbar-collapse-1.in" href.bind="row.href">${row.title}</a>
         </li>
       </ul>
 


### PR DESCRIPTION
When the screen size is small, like on a mobile phone, the navbar will collapse the menu items into an expandable hamburger menu. Clicking a menu item inside of the expanded menu should automatically collapse the menu. This change will auto collapse the expanded menu when the user clicks on a menu item. This way, the user does not have to go close the menu that is blocking their view.