### PR TITLE
fix(karma): properly set jspm paths for karma

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,7 +8,7 @@ System.config({
     ]
   },
   "paths": {
-    "*": "*.js",
+    "*": "dist/*.js",
     "github:*": "jspm_packages/github/*.js",
     "npm:*": "jspm_packages/npm/*.js",
     "aurelia-skeleton-navigation/*": "dist/*.js"
@@ -26,7 +26,7 @@ System.config({
     "babel": "npm:babel-core@5.1.13",
     "babel-runtime": "npm:babel-runtime@5.1.13",
     "bootstrap": "github:twbs/bootstrap@3.3.4",
-    "core-js": "npm:core-js@0.9.6",
+    "core-js": "npm:core-js@0.9.7",
     "css": "github:systemjs/plugin-css@0.1.10",
     "font-awesome": "npm:font-awesome@4.3.0",
     "traceur": "github:jmcriffey/bower-traceur@0.0.88",
@@ -38,7 +38,7 @@ System.config({
       "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.7.1",
       "aurelia-metadata": "github:aurelia/metadata@0.5.0",
       "aurelia-task-queue": "github:aurelia/task-queue@0.4.0",
-      "core-js": "npm:core-js@0.9.6"
+      "core-js": "npm:core-js@0.9.7"
     },
     "github:aurelia/bootstrapper@0.12.0": {
       "aurelia-event-aggregator": "github:aurelia/event-aggregator@0.4.0",
@@ -52,12 +52,12 @@ System.config({
       "aurelia-templating-binding": "github:aurelia/templating-binding@0.11.0",
       "aurelia-templating-resources": "github:aurelia/templating-resources@0.11.1",
       "aurelia-templating-router": "github:aurelia/templating-router@0.12.0",
-      "core-js": "npm:core-js@0.9.6"
+      "core-js": "npm:core-js@0.9.7"
     },
     "github:aurelia/dependency-injection@0.7.1": {
       "aurelia-logging": "github:aurelia/logging@0.4.0",
       "aurelia-metadata": "github:aurelia/metadata@0.5.0",
-      "core-js": "npm:core-js@0.9.6"
+      "core-js": "npm:core-js@0.9.7"
     },
     "github:aurelia/framework@0.11.0": {
       "aurelia-binding": "github:aurelia/binding@0.6.1",
@@ -68,15 +68,15 @@ System.config({
       "aurelia-path": "github:aurelia/path@0.6.1",
       "aurelia-task-queue": "github:aurelia/task-queue@0.4.0",
       "aurelia-templating": "github:aurelia/templating@0.11.2",
-      "core-js": "npm:core-js@0.9.6"
+      "core-js": "npm:core-js@0.9.7"
     },
     "github:aurelia/history-browser@0.4.0": {
       "aurelia-history": "github:aurelia/history@0.4.0",
-      "core-js": "npm:core-js@0.9.6"
+      "core-js": "npm:core-js@0.9.7"
     },
     "github:aurelia/http-client@0.8.0": {
       "aurelia-path": "github:aurelia/path@0.6.1",
-      "core-js": "npm:core-js@0.9.6"
+      "core-js": "npm:core-js@0.9.7"
     },
     "github:aurelia/loader-default@0.7.0": {
       "aurelia-loader": "github:aurelia/loader@0.6.0",
@@ -85,14 +85,14 @@ System.config({
     "github:aurelia/loader@0.6.0": {
       "aurelia-html-template-element": "github:aurelia/html-template-element@0.2.0",
       "aurelia-path": "github:aurelia/path@0.6.1",
-      "core-js": "npm:core-js@0.9.6",
+      "core-js": "npm:core-js@0.9.7",
       "webcomponentsjs": "github:webcomponents/webcomponentsjs@0.6.1"
     },
     "github:aurelia/metadata@0.5.0": {
-      "core-js": "npm:core-js@0.9.6"
+      "core-js": "npm:core-js@0.9.7"
     },
     "github:aurelia/route-recognizer@0.4.0": {
-      "core-js": "npm:core-js@0.9.6"
+      "core-js": "npm:core-js@0.9.7"
     },
     "github:aurelia/router@0.8.0": {
       "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.7.1",
@@ -100,7 +100,7 @@ System.config({
       "aurelia-history": "github:aurelia/history@0.4.0",
       "aurelia-path": "github:aurelia/path@0.6.1",
       "aurelia-route-recognizer": "github:aurelia/route-recognizer@0.4.0",
-      "core-js": "npm:core-js@0.9.6"
+      "core-js": "npm:core-js@0.9.7"
     },
     "github:aurelia/templating-binding@0.11.0": {
       "aurelia-binding": "github:aurelia/binding@0.6.1",
@@ -113,7 +113,7 @@ System.config({
       "aurelia-logging": "github:aurelia/logging@0.4.0",
       "aurelia-task-queue": "github:aurelia/task-queue@0.4.0",
       "aurelia-templating": "github:aurelia/templating@0.11.2",
-      "core-js": "npm:core-js@0.9.6"
+      "core-js": "npm:core-js@0.9.7"
     },
     "github:aurelia/templating-router@0.12.0": {
       "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.7.1",
@@ -131,7 +131,7 @@ System.config({
       "aurelia-metadata": "github:aurelia/metadata@0.5.0",
       "aurelia-path": "github:aurelia/path@0.6.1",
       "aurelia-task-queue": "github:aurelia/task-queue@0.4.0",
-      "core-js": "npm:core-js@0.9.6"
+      "core-js": "npm:core-js@0.9.7"
     },
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
@@ -177,7 +177,7 @@ System.config({
       "path": "github:jspm/nodelibs-path@0.1.0"
     },
     "github:twbs/bootstrap@3.3.4": {
-      "jquery": "github:components/jquery@2.1.3"
+      "jquery": "github:components/jquery@2.1.4"
     },
     "npm:amdefine@0.1.0": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
@@ -212,7 +212,7 @@ System.config({
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
-    "npm:core-js@0.9.6": {
+    "npm:core-js@0.9.7": {
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:core-util-is@1.0.1": {
@@ -277,3 +277,4 @@ System.config({
     }
   }
 });
+

--- a/index.html
+++ b/index.html
@@ -15,13 +15,6 @@
     <script src="jspm_packages/system.js"></script>
     <script src="config.js"></script>
     <script>
-     System.config({
-       "paths": {
-         "*": "dist/*.js"
-       }
-     });
-   </script>
-    <script>
       System.import('aurelia-bootstrapper');
     </script>
   </body>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,10 @@ module.exports = function(config) {
 
     jspm: {
       // Edit this to your needs
-      loadFiles: ['src/**/*.js', 'test/unit/**/*.js']
+      loadFiles: ['src/**/*.js', 'test/unit/**/*.js'],
+      paths: {
+        '*': '*.js'
+      }
     },
 
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "karma-babel-preprocessor": "^5.1.0",
     "karma-chrome-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.5",
-    "karma-jspm": "^1.1.4",
+    "karma-jspm": "^1.1.5",
     "object.assign": "^1.0.3",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",


### PR DESCRIPTION
This removes the need for the index.html jspm.path.* override and sets up the proper pathing for the test environment inside karma.conf

Fixes issue https://github.com/aurelia/skeleton-navigation/issues/55