### PR TITLE
feat(flickr): move canDeactivate prompt into Welcome

### DIFF
--- a/src/flickr.js
+++ b/src/flickr.js
@@ -16,8 +16,4 @@ export class Flickr{
       this.images = response.content.items;
     });
   }
-
-  canDeactivate(){
-    return confirm('Are you sure you want to leave?');
-  }
 }

--- a/src/welcome.js
+++ b/src/welcome.js
@@ -4,6 +4,7 @@ export class Welcome{
   heading = 'Welcome to the Aurelia Navigation App!';
   firstName = 'John';
   lastName = 'Doe';
+  previousValue = this.fullName;
 
   //Getters can't be observed with Object.observe, so they must be dirty checked.
   //However, if you tell Aurelia the dependencies, it no longer needs to dirty check the property.
@@ -14,7 +15,14 @@ export class Welcome{
   }
 
   welcome(){
+    this.previousValue = this.fullName;
     alert(`Welcome, ${this.fullName}!`);
+  }
+
+  canDeactivate() {
+    if (this.fullName !== this.previousValue) {
+      return confirm('Are you sure you want to leave?');
+    }
   }
 }
 


### PR DESCRIPTION
Move canDeactivate prompt into the Welcome view, and only trigger it when there are unsaved changes. I.e., when the name has been changed but "Submit" has not been clicked.

The prompt is a little annoying when you're just clicking around to test changes, so this prevents it from appearing on every navigation to a view.