### PR TITLE
fix(build): include source in source maps. resolve #111

### DIFF
--- a/build/paths.js
+++ b/build/paths.js
@@ -9,7 +9,6 @@ module.exports = {
   html: appRoot + '**/*.html',
   style: 'styles/**/*.css',
   output: outputRoot,
-  sourceMapRelativePath: '../' + appRoot,
   doc:'./doc',
   e2eSpecsSrc: 'test/e2e/src/*.js',
   e2eSpecsDist: 'test/e2e/dist/'

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -18,7 +18,7 @@ gulp.task('build-system', function () {
     .pipe(changed(paths.output, {extension: '.js'}))
     .pipe(sourcemaps.init({loadMaps: true}))
     .pipe(to5(assign({}, compilerOptions, {modules:'system'})))
-    .pipe(sourcemaps.write({includeContent: false, sourceRoot: paths.sourceMapRelativePath }))
+    .pipe(sourcemaps.write({includeContent: true}))
     .pipe(gulp.dest(paths.output));
 });
 


### PR DESCRIPTION
This PR switches to including the original source in the source map. This is the recommended practice per the `gulp-sourcemaps` [documentation](https://www.npmjs.com/package/gulp-sourcemaps).

>Including the content is the recommended way, because it "just works". When setting this to false you have to host the source files and set the correct sourceRoot.

This should make source maps work for all situations now. I tested this with `welcome.js` located at `src\foo\welcome.js` and serving the app from `http://localhost:9000/app/` as well as from `http://localhost:9000/`. In both cases (site served from root or subfolder), `foo\welcome.js` as well all of the other ES6 files were able to be debugged.