### PR TITLE
fix(css): fix print styles

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -33,6 +33,19 @@ body {
     overflow-y: auto;
 }
 
+@media print
+{
+  .page-host {
+    position: absolute;
+    left: 10px;
+    right: 0;
+    top: 50px;
+    bottom: 0;
+    overflow-y: inherit;
+    overflow-x: inherit;
+  }
+}
+
 section {
     margin: 0 20px;
 }


### PR DESCRIPTION
fixes print-preview problem with Chrome due to absolute positioned element with overflows set to auto/hidden

fixes issue https://github.com/aurelia/skeleton-navigation/issues/90