### PR TITLE
refactor(index): remove type from link tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <title>Aurelia</title>
-    <link rel="stylesheet" type="text/css" href="jspm_packages/npm/font-awesome@4.3.0/css/font-awesome.min.css">
-    <link rel="stylesheet" type="text/css" href="styles/styles.css">
+    <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.3.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="styles/styles.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body aurelia-app="animation-main">


### PR DESCRIPTION
The `type` attribute on the `link` tag is optional and defaults to `text/css` when `rel="stylesheet"`. Removing the `type` attributes gives a bit cleaner HTML and shaves a few bytes of the response.

[Spec](http://www.w3.org/html/wg/drafts/html/master/semantics.html#attr-link-type) (emphasis mine)
> The `type` attribute gives the MIME type of the linked resource. **It is purely advisory**. The value must be a valid MIME type.

[Spec](http://www.w3.org/html/wg/drafts/html/master/semantics.html#link-type-stylesheet)
> The default type for resources given by the `stylesheet` keyword is `text/css`.