### PR TITLE
fix(test): fix e2e test broken during fetch-client migration

### DIFF
--- a/aurelia.protractor.js
+++ b/aurelia.protractor.js
@@ -30,12 +30,13 @@ function loadAndWaitForAureliaPage(pageUrl) {
   });
 }
 
-function waitForHttpDone() {
+function waitForRouterComplete() {
   return browser.executeAsyncScript(
     'var cb = arguments[arguments.length - 1];' +
-    'document.addEventListener("aurelia-http-client-requests-drained", function (e) {' +
+    'document.querySelector("[aurelia-app]")' +
+    '.aurelia.subscribeOnce("router:navigation:complete", function() {' +
     '  cb(true)' +
-    '}, false);'
+    '});'
   ).then(function(result){
       return result;
   });
@@ -52,8 +53,8 @@ exports.setup = function(config) {
   // attach a new way to browser.get a page and wait for Aurelia to complete loading
   browser.loadAndWaitForAureliaPage = loadAndWaitForAureliaPage;
 
-  // wait for all http requests to finish
-  browser.waitForHttpDone = waitForHttpDone;
+  // wait for router navigations to complete
+  browser.waitForRouterComplete = waitForRouterComplete;
 };
 
 exports.teardown = function(config) {};

--- a/test/e2e/src/skeleton.po.js
+++ b/test/e2e/src/skeleton.po.js
@@ -10,6 +10,6 @@ export class PageObject_Skeleton {
 
   navigateTo(href) {
     element(by.css('a[href="' + href + '"]')).click();
-    return browser.waitForHttpDone();
+    return browser.waitForRouterComplete();
   }
 }


### PR DESCRIPTION
We now use the event aggregator to listen for router completed events instead of a custom event from the HTTP client.