### PR TITLE
perf(serve): speed up serve task

### DIFF
--- a/build/tasks/serve.js
+++ b/build/tasks/serve.js
@@ -6,6 +6,7 @@ var browserSync = require('browser-sync');
 // at http://localhost:9000
 gulp.task('serve', ['build'], function(done) {
   browserSync({
+    online: false,
     open: false,
     port: 9000,
     server: {


### PR DESCRIPTION
Speeds up serve, especially while offline.
http://www.browsersync.io/docs/options/#option-online