### PR TITLE
Declare jspm as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,19 @@ To run the app, follow these steps.
   ```shell
   npm install
   ```
-3. Ensure that [Gulp](http://gulpjs.com/) is installed. If you need to install it, use the following command:
+3. Ensure that [Gulp](http://gulpjs.com/) is installed globally. If you need to install it, use the following command:
 
   ```shell
   npm install -g gulp
   ```
-4. Ensure that [jspm](http://jspm.io/) is installed. If you need to install it, use the following command:
+  > **Note:** Gulp must be installed globally, but a local version will also be installed to ensure a compatible version is used for the project.
+4. Ensure that [jspm](http://jspm.io/) is installed globally. If you need to install it, use the following command:
 
   ```shell
   npm install -g jspm
   ```
+  > **Note:** jspm must be installed globally, but a local version will also be installed to ensure a compatible version is used for the project.
+
   > **Note:** jspm queries GitHub to install semver packages, but GitHub has a rate limit on anonymous API requests. It is advised that you configure jspm with your GitHub credentials in order to avoid problems. You can do this by executing `jspm registry config github` and following the prompts. If you choose to authorize jspm by an access token instead of giving your password (see GitHub `Settings > Personal Access Tokens`), `public_repo` access for the token is required.
 5. Install the client-side dependencies with jspm:
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gulp-yuidoc": "^0.1.2",
     "jasmine-core": "^2.1.3",
     "jshint-stylish": "^1.0.0",
+    "jspm": "^0.16.11",
     "karma": "^0.12.28",
     "karma-babel-preprocessor": "^5.2.1",
     "karma-chrome-launcher": "^0.1.7",


### PR DESCRIPTION
JSPM recommends having a local copy of jspm in addition to the global one.

> It is advisable to locally install to lock the version of jspm. This will ensure upgrades to the global jspm will not alter the behavior of your application.

Resolves #134 "Does it make sense to install jspm locally by default?"