### PR TITLE
fix(bundle): shoreten the long module name in bundle config

### DIFF
--- a/build/tasks/bundle.js
+++ b/build/tasks/bundle.js
@@ -7,10 +7,9 @@ var config = {
   bundles: {
     "dist/app-build": {
       includes: [
-        '*',
+        '[*]',
         '*.html!text',
         '*.css!text',
-        'bootstrap/css/bootstrap.css!text'
       ],
       options: {
         inject: true,
@@ -19,20 +18,27 @@ var config = {
     },
     "dist/aurelia": {
       includes: [
+        'aurelia-framework',
         'aurelia-bootstrapper',
         'aurelia-fetch-client',
         'aurelia-router',
         'aurelia-animator-css',
-        'github:aurelia/templating-binding',
-        'github:aurelia/templating-resources',
-        'github:aurelia/templating-router',
-        'github:aurelia/loader-default',
-        'github:aurelia/history-browser',
-        'github:aurelia/logging-console'
+        'aurelia/templating-binding',
+        'aurelia/templating-resources',
+        'aurelia/templating-router',
+        'aurelia/loader-default',
+        'aurelia/history-browser',
+        'aurelia/logging-console',
+        'bootstrap',
+        'bootstrap/css/bootstrap.css!text'
       ],
       options: {
         inject: true,
         minify: true
+        /* 
+         * Add bundle file revision/version. 
+         * rev: true 
+        */ 
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "e2e": "gulp serve e2e"
   },
   "devDependencies": {
-    "aurelia-bundler": "^0.1.6",
+    "aurelia-bundler": "^0.1.8",
     "aurelia-tools": "^0.1.3",
     "babel": "^5.8.23",
     "babel-eslint": "^4.1.3",


### PR DESCRIPTION
- Exclude all potential Aurelia modules from the `app-build` bundle.
- Further shorten the `module names without maps` in bundle config.

These changes now allows us to specify `aurelia/templating-binding` instead of `github:aurelia/templating-binding@0.16.0` or `github:aurelia/templating-binding` in the bundle config.
  