### PR TITLE
Add glyphicon font paths to export.json

### DIFF
--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/export.js
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/export.js
@@ -11,6 +11,7 @@ module.exports = {
     "jspm_packages/npm/font-awesome@4.5.0/css/font-awesome.min.css",
     "jspm_packages/npm/font-awesome@4.5.0/fonts/*",
     "jspm_packages/github/github/fetch@0.11.0.js",
-    "jspm_packages/github/github/fetch@0.11.0/fetch.js"
+    "jspm_packages/github/github/fetch@0.11.0/fetch.js",
+    "jspm_packages/github/twbs/bootstrap@3.3.6/fonts/*"
   ]
 };

--- a/skeleton-es2016/build/export.js
+++ b/skeleton-es2016/build/export.js
@@ -11,6 +11,7 @@ module.exports = {
     "jspm_packages/npm/font-awesome@4.5.0/css/font-awesome.min.css",
     "jspm_packages/npm/font-awesome@4.5.0/fonts/*",
     "jspm_packages/github/github/fetch@0.11.0.js",
-    "jspm_packages/github/github/fetch@0.11.0/fetch.js"
+    "jspm_packages/github/github/fetch@0.11.0/fetch.js",
+    "jspm_packages/github/twbs/bootstrap@3.3.6/fonts/*"
   ]
 };

--- a/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/export.js
+++ b/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/export.js
@@ -11,6 +11,7 @@ module.exports = {
     "jspm_packages/npm/font-awesome@4.5.0/css/font-awesome.min.css",
     "jspm_packages/npm/font-awesome@4.5.0/fonts/*",
     "jspm_packages/github/github/fetch@0.11.0.js",
-    "jspm_packages/github/github/fetch@0.11.0/fetch.js"
+    "jspm_packages/github/github/fetch@0.11.0/fetch.js",
+    "jspm_packages/github/twbs/bootstrap@3.3.6/fonts/*"
   ]
 };

--- a/skeleton-typescript/build/export.js
+++ b/skeleton-typescript/build/export.js
@@ -11,6 +11,7 @@ module.exports = {
     "jspm_packages/npm/font-awesome@4.5.0/css/font-awesome.min.css",
     "jspm_packages/npm/font-awesome@4.5.0/fonts/*",
     "jspm_packages/github/github/fetch@0.11.0.js",
-    "jspm_packages/github/github/fetch@0.11.0/fetch.js"
+    "jspm_packages/github/github/fetch@0.11.0/fetch.js",
+    "jspm_packages/github/twbs/bootstrap@3.3.6/fonts/*"
   ]
 };


### PR DESCRIPTION
**Overview of the Issue** - When bundling/exporting the skeleton app, Glyphicon fonts (provided by Bootstrap) are not exported.
**Motivation or Use Case** - While font-awesome is also used, if a beginner to Aurelia tries to use Glyphicon fonts as per Bootstrap docs, they will have to investigate bundling, which can be quite complex to a beginner.
**Related Issues** - Could not find related issues