### PR TITLE
chore(tests): update wallaby.js config files

### DIFF
--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/wallaby.js
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/wallaby.js
@@ -6,8 +6,8 @@ module.exports = function(wallaby) {
   return {
     files: [
 
-      {pattern: 'jspm_packages/system.js', instrument: false},
-      {pattern: 'config.js', instrument: false},
+      {pattern: 'wwwroot/jspm_packages/system.js', instrument: false},
+      {pattern: 'wwwroot/config.js', instrument: false},
 
       {pattern: 'src/**/*.js', load: false}
 
@@ -28,7 +28,8 @@ module.exports = function(wallaby) {
     },
 
     middleware: (app, express) => {
-      app.use('/jspm_packages', express.static(require('path').join(__dirname, 'jspm_packages')));
+      app.use('/wwwroot/jspm_packages', express.static(require('path').join(__dirname, 'wwwroot', 'jspm_packages')));
+      app.use('/jspm_packages', express.static(require('path').join(__dirname, 'wwwroot', 'jspm_packages')));
     },
 
     bootstrap: function(wallaby) {
@@ -40,7 +41,7 @@ module.exports = function(wallaby) {
 
       System.config({
         paths: {
-          '*': '*.js'
+          '*': '*'
         }
       });
       for (; i < len; i++) {
@@ -49,7 +50,7 @@ module.exports = function(wallaby) {
 
       Promise.all(promises).then(function() {
         wallaby.start();
-      });
+      }).catch(function (e) { setTimeout(function (){ throw e; }, 0); });
     },
 
     debug: false

--- a/skeleton-es2016/wallaby.js
+++ b/skeleton-es2016/wallaby.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-var, no-shadow, dot-notation */
 
-var babel = require('babel');
-
 module.exports = function(wallaby) {
   return {
     files: [
@@ -19,7 +17,6 @@ module.exports = function(wallaby) {
 
     compilers: {
       '**/*.js': wallaby.compilers.babel({
-        babel: babel,
         optional: [
           'es7.decorators',
           'es7.classProperties'
@@ -49,7 +46,7 @@ module.exports = function(wallaby) {
 
       Promise.all(promises).then(function() {
         wallaby.start();
-      });
+      }).catch(function (e) { setTimeout(function (){ throw e; }, 0); });
     },
 
     debug: false

--- a/skeleton-typescript/wallaby.js
+++ b/skeleton-typescript/wallaby.js
@@ -1,4 +1,3 @@
-
 module.exports = function (wallaby) {
 
   return {
@@ -8,7 +7,6 @@ module.exports = function (wallaby) {
       {pattern: 'config.js', instrument: false},
 
       {pattern: 'src/**/*.ts', load: false}
-
     ],
 
     tests: [
@@ -26,21 +24,8 @@ module.exports = function (wallaby) {
       System.config({
         paths: {
           "*": null,
-          "src/*": "src/*",
-          "typescript": "node_modules/typescript/lib/typescript.js",
-          "systemjs": "node_modules/systemjs/dist/system.js",
-          'system-polyfills': 'node_modules/systemjs/dist/system-polyfills.js',
-          'es6-module-loader': 'node_modules/es6-module-loader/dist/es6-module-loader.js'
-        },
-         packages: {
-          'test/unit': {
-            defaultExtension: 'ts'
-          },
-          'src': {
-            defaultExtension: 'ts'
-          }
-        },
-        transpiler: 'typescript'
+          "src/*": "src/*"
+        }
       });
 
       var promises = [];
@@ -50,7 +35,7 @@ module.exports = function (wallaby) {
 
       Promise.all(promises).then(function () {
         wallaby.start();
-      });
+      }).catch(function (e) { setTimeout(function (){ throw e; }, 0); });
     },
 
     debug: false


### PR DESCRIPTION
Updated wallaby.js configuration files, major changes:
- fixed asp.net project file to reflect the change of moving `jspm_packages ` to `wwwroot` folder, see [#238](https://github.com/aurelia/skeleton-navigation/issues/238#issuecomment-173925883);
- added better failed promise error reporting, as described in the [wallaby docs](http://wallabyjs.com/docs/integration/jspm.html);
- removed babel dependency from the config because wallaby resolves it automatically now. 