### PR TITLE
Removed aurelia-app attribute from prod template

### DIFF
--- a/skeleton-es2016-webpack/index.prod.html
+++ b/skeleton-es2016-webpack/index.prod.html
@@ -4,7 +4,7 @@
     <title>Aurelia</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
-  <body aurelia-app="main">
+  <body>
     <div class="splash">
       <div class="message">Aurelia Navigation Skeleton</div>
       <i class="fa fa-spinner fa-spin"></i>


### PR DESCRIPTION
The webpack skeleton uses explicit bootstrapping (in src/main.js) without the aurelia-app attribute because its needs to have an entry point for webpack anyway. Forgot to remove the attribute from the prod template.