### PR TITLE
fix(export): use the wwwroot folder as the root for the export instead of the project root

### DIFF
--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/paths.js
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/paths.js
@@ -1,5 +1,6 @@
 var appRoot = 'src/';
 var outputRoot = 'wwwroot/dist/';
+var exportSourceRoot = 'wwwroot/';
 var exportSrvRoot = 'export/';
 
 module.exports = {
@@ -9,6 +10,7 @@ module.exports = {
   css: appRoot + '**/*.css',
   style: 'styles/**/*.css',
   output: outputRoot,
+  exportSourceRoot: exportSourceRoot,
   exportSrv: exportSrvRoot,
   doc: './doc',
   e2eSpecsSrc: 'test/e2e/src/**/*.js',

--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/tasks/export-release.js
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/tasks/export-release.js
@@ -15,13 +15,15 @@ gulp.task('clean-export', function() {
 function getBundles() {
   var bl = [];
   for (b in bundles.bundles) {
-    bl.push(b + '.js');
+  	bl.push(paths.exportSourceRoot + b + '.js');
   }
   return bl;
 }
 
 function getExportList() {
-  return resources.list.concat(getBundles());
+  return resources.list.map(function (item) {
+    return paths.exportSourceRoot + item;
+  }).concat(getBundles());
 }
 
 gulp.task('export-copy', function() {

--- a/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/paths.js
+++ b/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/paths.js
@@ -1,5 +1,6 @@
 var appRoot = 'src/';
 var outputRoot = 'wwwroot/dist/';
+var exportSourceRoot = 'wwwroot/';
 var exporSrvtRoot = 'export/'
 
 module.exports = {
@@ -9,6 +10,7 @@ module.exports = {
   css: appRoot + '**/*.css',
   style: 'styles/**/*.css',
   output: outputRoot,
+	exportSourceRoot: exportSourceRoot,
   exportSrv: exporSrvtRoot,
   doc: './doc',
   e2eSpecsSrc: 'test/e2e/src/**/*.ts',

--- a/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/tasks/export-release.js
+++ b/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/tasks/export-release.js
@@ -15,13 +15,15 @@ gulp.task('clean-export', function() {
 function getBundles() {
   var bl = [];
   for (b in bundles.bundles) {
-    bl.push(b + '.js');
+    bl.push(paths.exportSourceRoot + b + '.js');
   }
   return bl;
 }
 
 function getExportList() {
-  return resources.list.concat(getBundles());
+  return resources.list.map(function(item) {
+		return paths.exportSourceRoot + item;
+	}).concat(getBundles());
 }
 
 gulp.task('export-copy', function() {


### PR DESCRIPTION
the gulp export task used the project root folder when trying to find resources from export.json. The fix changes this to instead use the wwwroot folder, so the existing export.json file works as intented.

no breaking changes I am aware of

note: this doesn't fix issue https://github.com/aurelia/skeleton-navigation/issues/284, that one should probably be a separate fix. Maybe a configuration flag whether to use bundles with rev numbers or not?

CLA signed