### PR TITLE
fix(test): run gulp test to completion during a test run with at least one failing test

### DIFF
--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/tasks/test.js
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/tasks/test.js
@@ -8,7 +8,7 @@ gulp.task('test', function(done) {
   new Karma({
     configFile: __dirname + '/../../karma.conf.js',
     singleRun: true
-  }, done).start();
+  }, function() { done(); }).start();
 });
 
 /**

--- a/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/tasks/test.js
+++ b/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/tasks/test.js
@@ -8,7 +8,7 @@ gulp.task('test', function (done) {
   new Karma({
     configFile: __dirname + '/../../karma.conf.js',
     singleRun: true
-  }, done).start();
+  }, function() { done(); }).start();
 });
 
 /**


### PR DESCRIPTION
the gulp test task, when at least one unit test fails, crashes with an unhandled exception, stacktrace: at formatError (C:\...\npm\node_modules\gulp\bin\gulp.js:169:10).
Reason for failure and suggested fix explained here: https://github.com/Swiip/generator-gulp-angular/issues/498#issuecomment-102185093
After applying this fix, the gulp test task runs to completion successfully even with failed tests.
Steps to repro: Make at least one unit test fail, run gulp test

no breaking changes