### PR TITLE
Adding Promise polyfill to support IE11

### DIFF
--- a/skeleton-es2016-webpack/package.json
+++ b/skeleton-es2016-webpack/package.json
@@ -38,6 +38,7 @@
     "aurelia-templating-binding": "^1.0.0-beta.1.1.1",
     "aurelia-templating-resources": "^1.0.0-beta.1.1.1",
     "aurelia-templating-router": "^1.0.0-beta.1.1.1",
+    "bluebird": "^3.3.4",
     "bootstrap": "^3.3.6",
     "font-awesome": "^4.5.0",
     "isomorphic-fetch": "^2.2.1"

--- a/skeleton-es2016-webpack/src/main.js
+++ b/skeleton-es2016-webpack/src/main.js
@@ -1,3 +1,4 @@
+var Promise = require('bluebird'); // Promise polyfill for IE11
 import {bootstrap} from 'aurelia-bootstrapper-webpack';
 
 import '../node_modules/bootstrap/dist/css/bootstrap.css';

--- a/skeleton-es2016-webpack/webpack.config.js
+++ b/skeleton-es2016-webpack/webpack.config.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var AureliaWebpackPlugin = require('aurelia-webpack-plugin');
+var ProvidePlugin = require('webpack/lib/ProvidePlugin');
 
 module.exports = {
   devServer: {
@@ -18,7 +19,10 @@ module.exports = {
     filename: 'bundle.js'
   },
   plugins: [
-    new AureliaWebpackPlugin()
+    new AureliaWebpackPlugin(),
+    new ProvidePlugin({
+      Promise: 'bluebird'
+    })
   ],
   module: {
     loaders: [

--- a/skeleton-es2016-webpack/webpack.prod.config.js
+++ b/skeleton-es2016-webpack/webpack.prod.config.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var AureliaWebpackPlugin = require('aurelia-webpack-plugin');
+var ProvidePlugin = require('webpack/lib/ProvidePlugin');
 var pkg = require('./package.json');
 
 var outputFileTemplateSuffix = '-' + pkg.version;
@@ -24,6 +25,9 @@ module.exports = {
       title: 'Aurelia webpack skeleton - ' + pkg.version,
       template: 'index.prod.html',
       filename: 'index.html'
+    }),
+    new ProvidePlugin({
+      Promise: 'bluebird'
     })
   ],
   resolve: {


### PR DESCRIPTION
Adding bluebird dependency as "Promise" polyfill for Internet Explorer 11 support. Also configured webpack ProvidePlugin so that Promise is exposed to other dependencies (as it is needed by aurelia-webpack-loader).

More info here: https://github.com/aurelia/bootstrapper-webpack/issues/3