### PR TITLE
chore(all): fix readme for electron case

### DIFF
--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/README.md
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/README.md
@@ -39,31 +39,6 @@ To run the app, follow these steps.
 
 > The Skeleton App uses [BrowserSync](http://www.browsersync.io/) for automated page refreshes on code/markup changes concurrently across multiple browsers. If you prefer to disable the mirroring feature set the [ghostMode option](http://www.browsersync.io/docs/options/#option-ghostMode) to false
 
-## Running The App under Electron
-
-To run the app under [Electron](http://electron.atom.io), follow these steps.
-
-1. Install [Electron](http://electron.atom.io)
-
-  ```shell
-  npm install electron-prebuilt -g
-  ```
-2. To start the app, execute the following command:
-
-  ```shell
-  electron index.js
-  ```
->**Note:** If you use electron every time or are packaging and so-forth, Then change this line in package.json from
-`"main": "dist/main.js",` to `"main": "index.js",`
-Build the app (this will give you a dist directory)
-```shell
-gulp build
-```
-To start the app, execute the following command:
-```shell
-   electron .
-```
-
 
 ## Bundling
 Bundling is performed by [Aurelia Bundler](http://github.com/aurelia/bundler). A gulp task is already configured for that. Use the following command to bundle the app:

--- a/skeleton-es2016/README.md
+++ b/skeleton-es2016/README.md
@@ -41,26 +41,65 @@ To run the app, follow these steps.
 
 ## Running The App under Electron
 
+#### Note:
+The first five steps below are identical to the first five steps for running this app the "standard' way, using the jspm / systemjs tooling. The difference is in the command to run the app, where the standard `gulp watch` command is replaced by the sequence of two commands:
+
+```shell
+gulp build
+electron index.js
+```
+
 To run the app under [Electron](http://electron.atom.io), follow these steps.
 
 1. Install [Electron](http://electron.atom.io)
 
   ```shell
   npm install electron-prebuilt -g
+```
+
+2. From the project folder, execute the following command:
+
+  ```shell
+  npm install
   ```
-2. To start the app, execute the following command:
+
+3. Ensure that [Gulp](http://gulpjs.com/) is installed globally. If you need to install it, use the following command:
+
+  ```shell
+  npm install -g gulp
+  ```
+  > **Note:** Gulp must be installed globally, but a local version will also be installed to ensure a compatible version is used for the project.
+
+4. Ensure that [jspm](http://jspm.io/) is installed globally. If you need to install it, use the following command:
+
+  ```shell
+  npm install -g jspm
+  ```
+  > **Note:** jspm must be installed globally, but a local version will also be installed to ensure a compatible version is used for the project.
+
+  > **Note:** jspm queries GitHub to install semver packages, but GitHub has a rate limit on anonymous API requests. It is advised that you configure jspm with your GitHub credentials in order to avoid problems. You can do this by executing `jspm registry config github` and following the prompts. If you choose to authorize jspm by an access token instead of giving your password (see GitHub `Settings > Personal Access Tokens`), `public_repo` access for the token is required.
+
+5. Install the client-side dependencies with jspm:
+
+  ```shell
+  jspm install -y
+  ```
+  >**Note:** Windows users, if you experience an error of "unknown command unzip" you can solve this problem by doing `npm install -g unzip` and then re-running `jspm install`.
+
+6. To build the app execute the following command (this will give you a dist directory)
+
+ ```shell
+    gulp build
+ ```
+
+7. To start the app, execute the following command:
 
   ```shell
   electron index.js
   ```
->**Note:** If you use electron every time or are packaging and so-forth, Then change this line in package.json from
-`"main": "dist/main.js",` to `"main": "index.js",`
-Build the app (this will give you a dist directory)
-```shell
-gulp build
-```
-To start the app, execute the following command:
-```shell
+>**Note:** If typing the command `electron index.js` is too much for you change this line in package.json from `"main": "dist/main.js",` to `"main": "index.js",`
+> Then, you can invoke electron by just typing
+ ```shell
    electron .
 ```
 

--- a/skeleton-typescript/README.md
+++ b/skeleton-typescript/README.md
@@ -1,4 +1,4 @@
-# aurelia-skeleton-navigation
+# aurelia-skeleton-navigation (typescript)
 
 ## Running The App
 
@@ -6,44 +6,48 @@ To run the app, follow these steps.
 
 1. Ensure that [NodeJS](http://nodejs.org/) is installed. This provides the platform on which the build tooling runs.
 2. From the project folder, execute the following command:
+
   ```shell
   npm install
   ```
 3. Ensure that [Gulp](http://gulpjs.com/) is installed globally. If you need to install it, use the following command:
+
   ```shell
   npm install -g gulp
   ```
   > **Note:** Gulp must be installed globally, but a local version will also be installed to ensure a compatible version is used for the project.
 4. Ensure that [jspm](http://jspm.io/) is installed globally. If you need to install it, use the following command:
+
   ```shell
   npm install -g jspm
   ```
   > **Note:** jspm must be installed globally, but a local version will also be installed to ensure a compatible version is used for the project.
 
-  > **Note:** Sometimes jspm queries GitHub to install packages, but GitHub has a rate limit on anonymous API requests. If you receive a rate limit error, you need to configure jspm with your GitHub credentials. You can do this by executing `jspm registry config github` and following the prompts. If you choose to authorize jspm by an access token instead of giving your password (see GitHub `Settings > Personal Access Tokens`), `public_repo` access for the token is required.
+  > **Note:** jspm queries GitHub to install semver packages, but GitHub has a rate limit on anonymous API requests. It is advised that you configure jspm with your GitHub credentials in order to avoid problems. You can do this by executing `jspm registry config github` and following the prompts. If you choose to authorize jspm by an access token instead of giving your password (see GitHub `Settings > Personal Access Tokens`), `public_repo` access for the token is required.
 5. Install the client-side dependencies with jspm:
 
   ```shell
   jspm install -y
   ```
   >**Note:** Windows users, if you experience an error of "unknown command unzip" you can solve this problem by doing `npm install -g unzip` and then re-running `jspm install`.
-
-6. Build the project:
-
-  ```shell
-  gulp build
-  ```
-
-7. To run the app, execute the following command:
+6. To run the app, execute the following command:
 
   ```shell
   gulp watch
   ```
-8. Browse to [http://localhost:9000](http://localhost:9000) to see the app. You can make changes in the code found under `src` and the browser should auto-refresh itself as you save files.
+7. Browse to [http://localhost:9000](http://localhost:9000) to see the app. You can make changes in the code found under `src` and the browser should auto-refresh itself as you save files.
 
-> The Skeleton App uses [BrowserSync](http://www.browsersync.io/) for automated page refreshes on code/markup changes concurrently accross multiple browsers. If you prefer to disable the mirroring feature set the [ghostMode option](http://www.browsersync.io/docs/options/#option-ghostMode) to false.
+> The Skeleton App uses [BrowserSync](http://www.browsersync.io/) for automated page refreshes on code/markup changes concurrently across multiple browsers. If you prefer to disable the mirroring feature set the [ghostMode option](http://www.browsersync.io/docs/options/#option-ghostMode) to false
 
 ## Running The App under Electron
+
+#### Note:
+The first five steps below are identical to the first five steps for running this app the "standard' way, using the jspm / systemjs tooling. The difference is in the command to run the app, where the standard `gulp watch` command is replaced by the sequence of two commands:
+
+```shell
+gulp build
+electron index.js
+```
 
 To run the app under [Electron](http://electron.atom.io), follow these steps.
 
@@ -51,25 +55,56 @@ To run the app under [Electron](http://electron.atom.io), follow these steps.
 
   ```shell
   npm install electron-prebuilt -g
+```
+
+2. From the project folder, execute the following command:
+
+  ```shell
+  npm install
   ```
-2. To start the app, execute the following command:
+
+3. Ensure that [Gulp](http://gulpjs.com/) is installed globally. If you need to install it, use the following command:
+
+  ```shell
+  npm install -g gulp
+  ```
+  > **Note:** Gulp must be installed globally, but a local version will also be installed to ensure a compatible version is used for the project.
+
+4. Ensure that [jspm](http://jspm.io/) is installed globally. If you need to install it, use the following command:
+
+  ```shell
+  npm install -g jspm
+  ```
+  > **Note:** jspm must be installed globally, but a local version will also be installed to ensure a compatible version is used for the project.
+
+  > **Note:** jspm queries GitHub to install semver packages, but GitHub has a rate limit on anonymous API requests. It is advised that you configure jspm with your GitHub credentials in order to avoid problems. You can do this by executing `jspm registry config github` and following the prompts. If you choose to authorize jspm by an access token instead of giving your password (see GitHub `Settings > Personal Access Tokens`), `public_repo` access for the token is required.
+
+5. Install the client-side dependencies with jspm:
+
+  ```shell
+  jspm install -y
+  ```
+  >**Note:** Windows users, if you experience an error of "unknown command unzip" you can solve this problem by doing `npm install -g unzip` and then re-running `jspm install`.
+
+6. To build the app execute the following command (this will give you a dist directory)
+
+ ```shell
+    gulp build
+ ```
+
+7. To start the app, execute the following command:
 
   ```shell
   electron index.js
   ```
->**Note:** If you use electron every time or are packaging and so-forth, Then change this line in package.json from
-`"main": "dist/main.js",` to `"main": "index.js",`
-Build the app (this will give you a dist directory)
-```shell
-gulp build
-```
-To start the app, execute the following command:
-```shell
+>**Note:** If typing the command `electron index.js` is too much for you change this line in package.json from `"main": "dist/main.js",` to `"main": "index.js",`
+> Then, you can invoke electron by just typing
+ ```shell
    electron .
 ```
 
-## Bundling
 
+## Bundling
 Bundling is performed by [Aurelia Bundler](http://github.com/aurelia/bundler). A gulp task is already configured for that. Use the following command to bundle the app:
 
   ```shell
@@ -79,7 +114,7 @@ Bundling is performed by [Aurelia Bundler](http://github.com/aurelia/bundler). A
 You can also unbundle using the command bellow:
 
   ```shell
-  gulp unbundle
+    gulp unbundle
   ```
 
 To start the bundled app, execute the following command:
@@ -88,9 +123,7 @@ To start the bundled app, execute the following command:
     gulp serve-bundle
   ```
 #### Configuration
-
 The configuration is done by ```bundles.js``` file.
-
 ##### Optional
 Under ```options``` of ```dist/aurelia``` add ```rev: true``` to add bundle file revision/version.
 


### PR DESCRIPTION
1. Corrected the electron section in readme for `skeleton-es2016` and `skeleton-typescript`
2. Removed the electron section in readme for `skeleton-es2016-asp.net5` - using electron in this environment makes no sense