### PR TITLE
wallaby config added to skeleton-es2016-webpack

### DIFF
--- a/skeleton-es2016-webpack/package.json
+++ b/skeleton-es2016-webpack/package.json
@@ -72,6 +72,7 @@
     "raw-loader": "^0.5.1",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
+    "wallaby-webpack": "0.0.21",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1"
   }

--- a/skeleton-es2016-webpack/test/unit/users.spec.js
+++ b/skeleton-es2016-webpack/test/unit/users.spec.js
@@ -1,4 +1,5 @@
 import './setup';
+import Promise from 'bluebird';
 import {Users} from '../../src/users';
 
 class HttpStub {

--- a/skeleton-es2016-webpack/wallaby.js
+++ b/skeleton-es2016-webpack/wallaby.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-var, no-shadow, dot-notation */
+var wallabyWebpack = require('wallaby-webpack');
+var wallabyPostprocessor = wallabyWebpack({
+  module: {
+    loaders: [
+      { test: /\.js$/, loader: 'babel', exclude: /node_modules/, query: { presets: ['es2015-loose', 'stage-1'], plugins: ['transform-decorators-legacy'] } },
+    ]
+  },
+});
+
+module.exports = function(wallaby) {
+  return {
+    files: [
+      { pattern: 'src/**/*.js', load: false },
+      { pattern: 'test/unit/setup.js', load: false }
+    ],
+
+    tests: [
+      { pattern: 'test/unit/**/*.spec.js', load: false }
+    ],
+
+    compilers: {
+      'src/**/*.js': wallaby.compilers.babel({
+        presets: [ 'es2015-loose', 'stage-1'],
+        plugins: [
+          'transform-decorators-legacy'
+        ]
+      })
+    },
+
+    postprocessor: wallabyPostprocessor,
+
+    setup: function() {
+      window.__moduleBundler.loadTests();
+    },
+
+    debug: false
+  };
+};


### PR DESCRIPTION
Added a wallaby config for the webpack skeleton, this required me to import the Promise polyfill in users.spec.js to get it to run properly with wallaby.

ref issue: https://github.com/aurelia/skeleton-navigation/issues/343