### PR TITLE
fix(skeleton-typescript-webpack): edit index.html and webpack.config.js

### DIFF
--- a/skeleton-typescript-webpack/index.html
+++ b/skeleton-typescript-webpack/index.html
@@ -9,6 +9,6 @@
       <div class="message">Aurelia Navigation Skeleton</div>
       <i class="fa fa-spinner fa-spin"></i>
     </div>
-    <script src="bundle.js"></script>
+    <script src="build/bundle.js"></script>
   </body>
 </html>

--- a/skeleton-typescript-webpack/webpack.config.js
+++ b/skeleton-typescript-webpack/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = {
   },
   output: {
     path: path.join(__dirname, 'build'),
+	publicPath: "./build/",
     filename: 'bundle.js'
   },
   plugins: [


### PR DESCRIPTION
Fix 'npm run build' problem. Now 'npm run dev' and 'npm run build' can be used for the same index.html.

close issue #402