### PR TITLE
fix(bundle): include jquery. needed for nav-bar dropdown

### DIFF
--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/bundles.js
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/bundles.js
@@ -28,7 +28,8 @@ module.exports = {
         "aurelia-history-browser",
         "aurelia-logging-console",
         "bootstrap",
-        "bootstrap/css/bootstrap.css!text"
+        "bootstrap/css/bootstrap.css!text",
+        "jquery"
       ],
       "options": {
         "inject": true,

--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/package.json
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/package.json
@@ -89,6 +89,7 @@
       "bootstrap": "github:twbs/bootstrap@^3.3.5",
       "fetch": "github:github/fetch@^0.11.0",
       "font-awesome": "npm:font-awesome@^4.5.0",
+      "jquery": "npm:jquery@^2.2.3",
       "text": "github:systemjs/plugin-text@^0.0.3"
     },
     "devDependencies": {}

--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/wwwroot/config.js
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/wwwroot/config.js
@@ -24,6 +24,7 @@ System.config({
     "bootstrap": "github:twbs/bootstrap@3.3.6",
     "fetch": "github:github/fetch@0.11.0",
     "font-awesome": "npm:font-awesome@4.5.0",
+    "jquery": "npm:jquery@2.2.3",
     "text": "github:systemjs/plugin-text@0.0.3",
     "github:twbs/bootstrap@3.3.6": {
       "jquery": "github:components/jquery@2.2.1"

--- a/skeleton-es2016-webpack/package.json
+++ b/skeleton-es2016-webpack/package.json
@@ -46,7 +46,7 @@
     "bootstrap": "^3.3.6",
     "font-awesome": "^4.5.0",
     "isomorphic-fetch": "^2.2.1",
-    "jquery": "^2.2.2"
+    "jquery": "^2.2.3"
   },
   "devDependencies": {
     "aurelia-tools": "^0.1.18",

--- a/skeleton-es2016-webpack/src/main.js
+++ b/skeleton-es2016-webpack/src/main.js
@@ -3,8 +3,8 @@ var Promise = require('bluebird'); // Promise polyfill for IE11
 
 import { bootstrap } from 'aurelia-bootstrapper-webpack';
 
-import '../node_modules/jquery/dist/jquery.js';
-import '../node_modules/bootstrap/dist/js/bootstrap.js';
+import 'bootstrap';
+
 import '../node_modules/bootstrap/dist/css/bootstrap.css';
 import '../node_modules/font-awesome/css/font-awesome.css';
 import '../styles/styles.css';

--- a/skeleton-es2016/build/bundles.js
+++ b/skeleton-es2016/build/bundles.js
@@ -28,7 +28,8 @@ module.exports = {
         "aurelia-history-browser",
         "aurelia-logging-console",
         "bootstrap",
-        "bootstrap/css/bootstrap.css!text"
+        "bootstrap/css/bootstrap.css!text",
+        "jquery"
       ],
       "options": {
         "inject": true,

--- a/skeleton-es2016/config.js
+++ b/skeleton-es2016/config.js
@@ -23,6 +23,7 @@ System.config({
     "bootstrap": "github:twbs/bootstrap@3.3.6",
     "fetch": "github:github/fetch@0.11.0",
     "font-awesome": "npm:font-awesome@4.5.0",
+    "jquery": "npm:jquery@2.2.3",
     "text": "github:systemjs/plugin-text@0.0.3",
     "github:twbs/bootstrap@3.3.6": {
       "jquery": "github:components/jquery@2.2.1"

--- a/skeleton-es2016/package.json
+++ b/skeleton-es2016/package.json
@@ -81,6 +81,7 @@
       "bootstrap": "github:twbs/bootstrap@^3.3.5",
       "fetch": "github:github/fetch@^0.11.0",
       "font-awesome": "npm:font-awesome@^4.5.0",
+      "jquery": "npm:jquery@^2.2.3",
       "text": "github:systemjs/plugin-text@^0.0.3"
     },
     "devDependencies": {}

--- a/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/bundles.js
+++ b/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/bundles.js
@@ -28,7 +28,8 @@ module.exports = {
         "aurelia-history-browser",
         "aurelia-logging-console",
         "bootstrap",
-        "bootstrap/css/bootstrap.css!text"
+        "bootstrap/css/bootstrap.css!text",
+        "jquery"
       ],
       "options": {
         "inject": true,

--- a/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/package.json
+++ b/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/package.json
@@ -69,6 +69,7 @@
       "bootstrap": "github:twbs/bootstrap@^3.3.5",
       "fetch": "github:github/fetch@^0.11.0",
       "font-awesome": "npm:font-awesome@^4.5.0",
+      "jquery": "npm:jquery@^2.2.3",
       "text": "github:systemjs/plugin-text@^0.0.3"
     },
     "devDependencies": {}

--- a/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/wwwroot/config.js
+++ b/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/wwwroot/config.js
@@ -24,6 +24,7 @@ System.config({
     "bootstrap": "github:twbs/bootstrap@3.3.6",
     "fetch": "github:github/fetch@0.11.0",
     "font-awesome": "npm:font-awesome@4.5.0",
+    "jquery": "npm:jquery@2.2.3",
     "text": "github:systemjs/plugin-text@0.0.3",
     "github:twbs/bootstrap@3.3.6": {
       "jquery": "github:components/jquery@2.2.1"

--- a/skeleton-typescript-webpack/package.json
+++ b/skeleton-typescript-webpack/package.json
@@ -46,7 +46,8 @@
     "aurelia-templating-router": "^1.0.0-beta.1.1.1",
     "bootstrap": "^3.3.6",
     "font-awesome": "^4.5.0",
-    "isomorphic-fetch": "^2.2.1"
+    "isomorphic-fetch": "^2.2.1",
+    "jquery": "^2.2.3"
   },
   "devDependencies": {
     "aurelia-tools": "^0.1.18",

--- a/skeleton-typescript-webpack/src/main.ts
+++ b/skeleton-typescript-webpack/src/main.ts
@@ -1,6 +1,8 @@
 ﻿import {Aurelia} from 'aurelia-framework';
 import {bootstrap} from 'aurelia-bootstrapper-webpack';
 
+import 'bootstrap';
+
 import '../node_modules/bootstrap/dist/css/bootstrap.css';
 import '../node_modules/font-awesome/css/font-awesome.css';
 import '../styles/styles.css';

--- a/skeleton-typescript-webpack/webpack.config.js
+++ b/skeleton-typescript-webpack/webpack.config.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var AureliaWebpackPlugin = require('aurelia-webpack-plugin');
+var ProvidePlugin = require('webpack/lib/ProvidePlugin');
 
 module.exports = {
   resolve: {
@@ -21,7 +22,10 @@ module.exports = {
     filename: 'bundle.js'
   },
   plugins: [
-    new AureliaWebpackPlugin()
+    new AureliaWebpackPlugin(),
+    new ProvidePlugin({
+      jQuery: 'jquery'
+    })
   ],
   module: {
     loaders: [

--- a/skeleton-typescript-webpack/webpack.prod.config.js
+++ b/skeleton-typescript-webpack/webpack.prod.config.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var AureliaWebpackPlugin = require('aurelia-webpack-plugin');
+var ProvidePlugin = require('webpack/lib/ProvidePlugin');
 var pkg = require('./package.json');
 
 var outputFileTemplateSuffix = '-' + pkg.version;
@@ -24,6 +25,9 @@ module.exports = {
       title: 'Aurelia webpack skeleton - ' + pkg.version,
       template: 'index.prod.html',
       filename: 'index.html'
+    }),
+    new ProvidePlugin({
+      jQuery: 'jquery'
     })
   ],
   resolve: {

--- a/skeleton-typescript/build/bundles.js
+++ b/skeleton-typescript/build/bundles.js
@@ -28,7 +28,8 @@ module.exports = {
         "aurelia-history-browser",
         "aurelia-logging-console",
         "bootstrap",
-        "bootstrap/css/bootstrap.css!text"
+        "bootstrap/css/bootstrap.css!text",
+        "jquery"
       ],
       "options": {
         "inject": true,

--- a/skeleton-typescript/config.js
+++ b/skeleton-typescript/config.js
@@ -23,6 +23,7 @@ System.config({
     "bootstrap": "github:twbs/bootstrap@3.3.6",
     "fetch": "github:github/fetch@0.11.0",
     "font-awesome": "npm:font-awesome@4.5.0",
+    "jquery": "npm:jquery@2.2.3",
     "text": "github:systemjs/plugin-text@0.0.3",
     "github:twbs/bootstrap@3.3.6": {
       "jquery": "github:components/jquery@2.2.1"

--- a/skeleton-typescript/package.json
+++ b/skeleton-typescript/package.json
@@ -74,6 +74,7 @@
       "bootstrap": "github:twbs/bootstrap@^3.3.5",
       "fetch": "github:github/fetch@^0.11.0",
       "font-awesome": "npm:font-awesome@^4.5.0",
+      "jquery": "npm:jquery@^2.2.3",
       "text": "github:systemjs/plugin-text@^0.0.3"
     },
     "devDependencies": {}


### PR DESCRIPTION
- all but vs versions tested. but it's just the same for all of them anyways
- for the webpack version, i prefer my approach
- i considered using the jquery coming with the bootstrap install, but possible ways to do that would break just too easily. an own jquery installation seems preferable 

replacing: https://github.com/aurelia/skeleton-navigation/pull/410