### PR TITLE
chore(tests): update wallaby.js config files to babel 6

### DIFF
--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/package.json
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "aurelia-bundler": "^0.3.0",
     "aurelia-tools": "^0.1.3",
+    "babel-core": "^6.7.2",
     "babel-eslint": "^5.0.0",
     "babel-plugin-syntax-flow": "^6.5.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",

--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/wallaby.js
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/wallaby.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-var, no-shadow, dot-notation */
 
-var babel = require('babel');
-
 module.exports = function(wallaby) {
   return {
     files: [
@@ -20,10 +18,11 @@ module.exports = function(wallaby) {
 
     compilers: {
       '**/*.js': wallaby.compilers.babel({
-        babel: babel,
-        optional: [
-          'es7.decorators',
-          'es7.classProperties'
+        presets: [ 'es2015-loose', 'stage-1'],
+        plugins: [
+          'syntax-flow',
+          'transform-decorators-legacy',
+          'transform-flow-strip-types'
         ]
       })
     },

--- a/skeleton-es2016/package.json
+++ b/skeleton-es2016/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "aurelia-bundler": "^0.3.0",
     "aurelia-tools": "^0.1.18",
+    "babel-core": "^6.7.2",
     "babel-eslint": "^5.0.0",
     "babel-plugin-syntax-flow": "^6.5.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",

--- a/skeleton-es2016/wallaby.js
+++ b/skeleton-es2016/wallaby.js
@@ -18,9 +18,11 @@ module.exports = function(wallaby) {
 
     compilers: {
       '**/*.js': wallaby.compilers.babel({
-        optional: [
-          'es7.decorators',
-          'es7.classProperties'
+        presets: [ 'es2015-loose', 'stage-1'],
+        plugins: [
+          'syntax-flow',
+          'transform-decorators-legacy',
+          'transform-flow-strip-types'
         ]
       })
     },


### PR DESCRIPTION
Looks like karma configs in these projects are using babel 6, also `skeleton-es2016-webpack` wallaby config is using babel 6, so I have updated the rest of wallaby configs use babel 6.