### PR TITLE
Update function getBundles() in export-release.js

### DIFF
--- a/skeleton-es2016/build/tasks/export-release.js
+++ b/skeleton-es2016/build/tasks/export-release.js
@@ -15,7 +15,7 @@ gulp.task('clean-export', function() {
 function getBundles() {
   var bl = [];
   for (var b in bundles.bundles) {
-    bl.push(b + '.js');
+    bl.push(b + '*.js');
   }
   return bl;
 }


### PR DESCRIPTION
This fixes issue #409, where bundled javascript files with `rev: true` set on the bundle are not copied to the export directory. This solution adds a single wildcard character into the glob that ensures files with a thumbprint ID in their name are included in the export-copy task. e.g. currently this file is copied correctly:

aurelia.js

...but this file is not copied:

aurelia-c440bb4410.js

This PR adds a wildcard char to the glob that ensures both filenames would be copied to the export correctly.