### PR TITLE
chore(jspm): include src subfolders into bundle

### DIFF
--- a/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/bundles.js
+++ b/skeleton-es2016-asp.net5/src/skeleton-navigation-es2016-vs/build/bundles.js
@@ -2,9 +2,9 @@ module.exports = {
   "bundles": {
     "dist/app-build": {
       "includes": [
-        "[*.js]",
-        "*.html!text",
-        "*.css!text"
+        "[**/*.js]",
+        "**/*.html!text",
+        "**/*.css!text"
       ],
       "options": {
         "inject": true,

--- a/skeleton-es2016/build/bundles.js
+++ b/skeleton-es2016/build/bundles.js
@@ -2,9 +2,9 @@ module.exports = {
   "bundles": {
     "dist/app-build": {
       "includes": [
-        "[*.js]",
-        "*.html!text",
-        "*.css!text"
+        "[**/*.js]",
+        "**/*.html!text",
+        "**/*.css!text"
       ],
       "options": {
         "inject": true,

--- a/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/bundles.js
+++ b/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/build/bundles.js
@@ -2,9 +2,9 @@ module.exports = {
   "bundles": {
     "dist/app-build": {
       "includes": [
-        "[*.js]",
-        "*.html!text",
-        "*.css!text"
+        "[**/*.js]",
+        "**/*.html!text",
+        "**/*.css!text"
       ],
       "options": {
         "inject": true,

--- a/skeleton-typescript/build/bundles.js
+++ b/skeleton-typescript/build/bundles.js
@@ -2,9 +2,9 @@ module.exports = {
   "bundles": {
     "dist/app-build": {
       "includes": [
-        "[*.js]",
-        "*.html!text",
-        "*.css!text"
+        "[**/*.js]",
+        "**/*.html!text",
+        "**/*.css!text"
       ],
       "options": {
         "inject": true,


### PR DESCRIPTION
With this change, all files and subfolders of the 'src' directory are included in the app-bundle. I think that is a useful default.