### PR TITLE
chore(all): add wallaby config file

### DIFF
--- a/skeleton-typescript-webpack/package.json
+++ b/skeleton-typescript-webpack/package.json
@@ -69,6 +69,7 @@
     "ts-node": "^0.7.2",
     "typescript": "^1.8.7",
     "url-loader": "^0.5.7",
+    "wallaby-webpack": "0.0.22",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1"
   }

--- a/skeleton-typescript-webpack/wallaby.js
+++ b/skeleton-typescript-webpack/wallaby.js
@@ -1,0 +1,24 @@
+/* eslint-disable no-var, no-shadow, dot-notation */
+var wallabyWebpack = require('wallaby-webpack');
+var wallabyPostprocessor = wallabyWebpack({});
+
+module.exports = function(wallaby) {
+  return {
+    files: [
+      { pattern: 'src/**/*.ts', load: false },
+      { pattern: 'test/unit/setup.ts', load: false }
+    ],
+
+    tests: [
+      { pattern: 'test/unit/**/*.spec.ts', load: false }
+    ],
+
+    postprocessor: wallabyPostprocessor,
+
+    setup: function() {
+      window.__moduleBundler.loadTests();
+    },
+
+    debug: false
+  };
+};


### PR DESCRIPTION
Add a wallaby.js file for skeleton-typescript-webpack.
Still has an issue with Promise not being defined when running tests with wallaby.