### PR TITLE
chore(asp.net5): fixed TypeScript transpile in Visual Studio build

### DIFF
--- a/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/gulpfile.js
+++ b/skeleton-typescript-asp.net5/src/skeleton-navigation-typescript-vs/gulpfile.js
@@ -1,4 +1,4 @@
-﻿/// <binding BeforeBuild='build-html, build-css, build-jspm' Clean='clean' />
+﻿/// <binding BeforeBuild='build' Clean='clean' />
 // all gulp tasks are located in the ./build/tasks directory
 // gulp configuration is in files in ./build directory
 require('require-dir')('build/tasks');


### PR DESCRIPTION
BeforeBuild binding for visual studio was set to 'build-html, build-css, build-jspm' instead of just using 'build'. 'build-system' was missing and so TypeScript files were not transpiled.