### PR TITLE
refactor(index): use systemjs to load font-awesome fix #405

### DIFF
--- a/skeleton-es2016/index.html
+++ b/skeleton-es2016/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <title>Aurelia</title>
-    <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.6.1/css/font-awesome.min.css">
     <link rel="stylesheet" href="styles/styles.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
@@ -16,6 +15,7 @@
     <script src="jspm_packages/system.js"></script>
     <script src="config.js"></script>
     <script>
+      System.import('font-awesome/css/font-awesome.min.css!css');
       System.import('aurelia-bootstrapper');
     </script>
   </body>

--- a/skeleton-es2016/package.json
+++ b/skeleton-es2016/package.json
@@ -80,6 +80,7 @@
       "aurelia-templating-resources": "npm:aurelia-templating-resources@^1.0.0-beta.1.1.3",
       "aurelia-templating-router": "npm:aurelia-templating-router@^1.0.0-beta.1.1.2",
       "bootstrap": "github:twbs/bootstrap@^3.3.5",
+      "css": "github:systemjs/plugin-css@^0.1.21",
       "fetch": "github:github/fetch@^0.11.0",
       "font-awesome": "npm:font-awesome@^4.5.0",
       "jquery": "npm:jquery@^2.2.3",


### PR DESCRIPTION
I did not push the changes to `config.js`

Please run this with throttling in Chrome to decide if this is worth merging. It's nearly as fast to load the spinner as the existing solution on low-latency, but is visibly slower with high latency.

Incidentally, I tried bundling FA in to the `aurelia` bundle, and it fails every time on Windows. 