### PR TITLE
chore(export): normalize jspm sourced resources

### DIFF
--- a/skeleton-es2016/build/bundles.js
+++ b/skeleton-es2016/build/bundles.js
@@ -29,6 +29,7 @@ module.exports = {
         "aurelia-logging-console",
         "bootstrap",
         "bootstrap/css/bootstrap.css!text",
+        "fetch",
         "jquery"
       ],
       "options": {

--- a/skeleton-es2016/build/export.js
+++ b/skeleton-es2016/build/export.js
@@ -1,17 +1,34 @@
+// this file provides a list of unbundled files that
+// need to be included when exporting the application
+// for production.
 module.exports = {
-  "list": [
-    "index.html",
-    "config.js",
-    "favicon.ico",
-    "LICENSE",
-    "jspm_packages/system.js",
-    "jspm_packages/system-polyfills.js",
-    "jspm_packages/system-csp-production.js",
-    "styles/styles.css",
-    "jspm_packages/npm/font-awesome@4.5.0/css/font-awesome.min.css",
-    "jspm_packages/npm/font-awesome@4.5.0/fonts/*",
-    "jspm_packages/github/github/fetch@0.11.0.js",
-    "jspm_packages/github/github/fetch@0.11.0/fetch.js",
-    "jspm_packages/github/twbs/bootstrap@3.3.6/fonts/*"
+  'list': [
+    'index.html',
+    'config.js',
+    'favicon.ico',
+    'LICENSE',
+    'jspm_packages/system.js',
+    'jspm_packages/system-polyfills.js',
+    'jspm_packages/system-csp-production.js',
+    'styles/styles.css'
+  ],
+  // this section lists any jspm packages that have
+  // unbundled resources that need to be exported.
+  // these files are in versioned folders and thus
+  // must be 'normalized' by jspm to get the proper
+  // path.
+  'normalize': [
+    [
+      // include font-awesome.css and its fonts files
+      'font-awesome', [
+        '/css/font-awesome.min.css',
+        '/fonts/*'
+      ]
+    ], [
+      // include bootstrap's font files
+      'bootstrap', [
+        '/fonts/*'
+      ]
+    ]
   ]
 };

--- a/skeleton-es2016/build/tasks/export-release.js
+++ b/skeleton-es2016/build/tasks/export-release.js
@@ -1,20 +1,17 @@
-var gulp = require('gulp');
-var runSequence = require('run-sequence');
-var del = require('del');
-var vinylPaths = require('vinyl-paths');
-var paths = require('../paths');
-var bundles = require('../bundles.js');
-var resources = require('../export.js');
+'use strict';
 
-// deletes all files in the output path
-gulp.task('clean-export', function() {
-  return gulp.src([paths.exportSrv])
-    .pipe(vinylPaths(del));
-});
+const gulp = require('gulp');
+const runSequence = require('run-sequence');
+const del = require('del');
+const vinylPaths = require('vinyl-paths');
+const jspm = require('jspm');
+const paths = require('../paths');
+const bundles = require('../bundles.js');
+const resources = require('../export.js');
 
 function getBundles() {
-  var bl = [];
-  for (var b in bundles.bundles) {
+  let bl = [];
+  for (let b in bundles.bundles) {
     bl.push(b + '*.js');
   }
   return bl;
@@ -24,9 +21,41 @@ function getExportList() {
   return resources.list.concat(getBundles());
 }
 
+function normalizeExportPaths() {
+  const pathsToNormalize = resources.normalize;
+
+  let promises =  pathsToNormalize.map(pathSet => {
+    const packageName = pathSet[ 0 ];
+    const fileList = pathSet[ 1 ];
+
+    return jspm.normalize(packageName).then((normalized) => {
+      const packagePath = normalized.substring(normalized.indexOf('jspm_packages'), normalized.lastIndexOf('.js'));
+      return fileList.map(file => packagePath + file);
+    });
+  });
+
+  return Promise.all(promises)
+    .then((normalizedPaths) => {
+      return normalizedPaths.reduce((prev, curr) => prev.concat(curr), []);
+    });
+}
+
+// deletes all files in the output path
+gulp.task('clean-export', function() {
+  return gulp.src([ paths.exportSrv ])
+    .pipe(vinylPaths(del));
+});
+
 gulp.task('export-copy', function() {
-  return gulp.src(getExportList(), {base: '.'})
+  return gulp.src(getExportList(), { base: '.' })
     .pipe(gulp.dest(paths.exportSrv));
+});
+
+gulp.task('export-normalized-resources', function() {
+  return normalizeExportPaths().then(normalizedPaths => {
+    return gulp.src(normalizedPaths, { base: '.' })
+      .pipe(gulp.dest(paths.exportSrv));
+  });
 });
 
 // use after prepare-release
@@ -34,6 +63,7 @@ gulp.task('export', function(callback) {
   return runSequence(
     'bundle',
     'clean-export',
+    'export-normalized-resources',
     'export-copy',
     callback
   );


### PR DESCRIPTION
Changes: 

- Added fetch to the bundle. It wasn't included due to it being imported in a VM, but not in `aurelia-fetch-client`.
- Updated `export-release.js` to use ES2015 features. Added a new tasks that gets the path to any jspm package and then uses that path to copy resources from that jspm package's folder. This removes the need to keep the file list in `export.js` manually up to date.
- Modifed `export.js` to include the necessary structure for exporting `font-awesome` and its font files as well as the font files for `bootstrap`. 

I have not tested this on `node` versions below `5.10.0`, but the research I have done leads me to believe it should work as I don't believe I am using any ES2015 features that haven't been supported since Node 4.x, but I think this should be tested on the latest Node 4.x LTS release.