### PR TITLE
Allow for sweet sweet bable lovin on Windows too

### DIFF
--- a/skeleton-webpack/config/webpack.base.js
+++ b/skeleton-webpack/config/webpack.base.js
@@ -196,7 +196,7 @@ const config = {
       {
         test: /\.js$/,
         loader: 'babel',
-        include: /node_modules\/aurelia-[a-z\-]+\/dist\/es\d+/,
+        include: /node_modules[\/\\]aurelia-[a-z\-]+[\/\\]dist[\/\\]es\d+/,
         query: {
           presets: ['es2015-loose-native-modules'],
           cacheDirectory: true,


### PR DESCRIPTION
The current skeleton didn't apply the babel loader to aurelia es215 files on windows due to the path separator character.

This patch simply tests for both `\` and `/` in the include regex