### PR TITLE
fix(build): return non-zero error code on test failures

### DIFF
--- a/skeleton-esnext-aspnetcore/src/skeleton-navigation-esnext-vs/build/tasks/test.js
+++ b/skeleton-esnext-aspnetcore/src/skeleton-navigation-esnext-vs/build/tasks/test.js
@@ -8,7 +8,7 @@ gulp.task('test', function(done) {
   new Karma({
     configFile: __dirname + '/../../karma.conf.js',
     singleRun: true
-  }, function() { done(); }).start();
+  }, done).start();
 });
 
 /**

--- a/skeleton-esnext/build/tasks/test.js
+++ b/skeleton-esnext/build/tasks/test.js
@@ -8,7 +8,7 @@ gulp.task('test', function(done) {
   new Karma({
     configFile: __dirname + '/../../karma.conf.js',
     singleRun: true
-  }, function() { done(); }).start();
+  }, done).start();
 });
 
 /**
@@ -17,7 +17,7 @@ gulp.task('test', function(done) {
 gulp.task('tdd', function(done) {
   new Karma({
     configFile: __dirname + '/../../karma.conf.js'
-  }, function() { done(); }).start();
+  }, done).start();
 });
 
 /**

--- a/skeleton-typescript-aspnetcore/src/skeleton-navigation-typescript-vs/build/tasks/test.js
+++ b/skeleton-typescript-aspnetcore/src/skeleton-navigation-typescript-vs/build/tasks/test.js
@@ -8,7 +8,7 @@ gulp.task('test', function (done) {
   new Karma({
     configFile: __dirname + '/../../karma.conf.js',
     singleRun: true
-  }, function() { done(); }).start();
+  }, done).start();
 });
 
 /**

--- a/skeleton-typescript/build/tasks/test.js
+++ b/skeleton-typescript/build/tasks/test.js
@@ -8,7 +8,7 @@ gulp.task('test', function (done) {
   new Karma({
     configFile: __dirname + '/../../karma.conf.js',
     singleRun: true
-  }, function() { done(); }).start();
+  }, done).start();
 });
 
 /**
@@ -17,5 +17,5 @@ gulp.task('test', function (done) {
 gulp.task('tdd', function (done) {
   new Karma({
     configFile: __dirname + '/../../karma.conf.js'
-  }, function() { done(); }).start();
+  }, done).start();
 });


### PR DESCRIPTION
This fixed `gulp test` to return the proper error codes on test failures instead of always returning `0`.

Helpful to avoid having automated builds turn out green even when tests are failing.