### PR TITLE
fix(skeleton_navigation_typescript_aspnetcore): comment out MVC code

### DIFF
--- a/skeleton-typescript-aspnetcore/src/skeleton-navigation-typescript-vs/Startup.cs
+++ b/skeleton-typescript-aspnetcore/src/skeleton-navigation-typescript-vs/Startup.cs
@@ -35,7 +35,7 @@ namespace skeleton_navigation_typescript_vs
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            // Add framework services.
+            // Add framework services. 
 
             services.AddApplicationInsightsTelemetry(Configuration);
 

--- a/skeleton-typescript-aspnetcore/src/skeleton-navigation-typescript-vs/Startup.cs
+++ b/skeleton-typescript-aspnetcore/src/skeleton-navigation-typescript-vs/Startup.cs
@@ -39,8 +39,6 @@ namespace skeleton_navigation_typescript_vs
 
             services.AddApplicationInsightsTelemetry(Configuration);
 
-            services.AddMvc();
-
             // Add application services.
         }
 
@@ -59,17 +57,12 @@ namespace skeleton_navigation_typescript_vs
             {
                 app.UseExceptionHandler("/Home/Error");
             }
-
+            app.UseDefaultFiles();
             app.UseStaticFiles();
 
             // Add external authentication middleware below. To configure them please see http://go.microsoft.com/fwlink/?LinkID=532715
 
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
+            
         }
     }
 }

--- a/skeleton-typescript-aspnetcore/src/skeleton-navigation-typescript-vs/Startup.cs
+++ b/skeleton-typescript-aspnetcore/src/skeleton-navigation-typescript-vs/Startup.cs
@@ -40,6 +40,11 @@ namespace skeleton_navigation_typescript_vs
             services.AddApplicationInsightsTelemetry(Configuration);
 
             // Add application services.
+            
+            // To enable Mvc, uncomment this line as well as the Mvc configuration in Configure below. 
+            //services.AddMvc();
+            
+            
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -57,11 +62,20 @@ namespace skeleton_navigation_typescript_vs
             {
                 app.UseExceptionHandler("/Home/Error");
             }
+            // Comment this line to NOT use index.html as the startup file. For example, when using Mvc.
             app.UseDefaultFiles();
-            app.UseStaticFiles();
+            
+            app.UseStaticFiles();//Required when serving any static files.
 
             // Add external authentication middleware below. To configure them please see http://go.microsoft.com/fwlink/?LinkID=532715
-
+            
+            // Uncomment this line to use Mvc as the startup route.
+            //app.UseMvc(routes =>
+            //{
+            //    routes.MapRoute(
+            //        name: "default",
+            //        template: "{controller=Home}/{action=Index}/{id?}");
+            //});
             
         }
     }


### PR DESCRIPTION
Added:

```
app.UseDefaultFiles();
```
so that index.html will be served as the default document.

Removed
```
app.useMvc...
```
As Mvc routes are not being used.

Also removed:
```
services.AddMvc();
```
as MVC is not being used.