### PR TITLE
chore(build): update to minify html on build

### DIFF
--- a/skeleton-esnext-aspnetcore/src/skeleton/build/tasks/build.js
+++ b/skeleton-esnext-aspnetcore/src/skeleton/build/tasks/build.js
@@ -9,6 +9,7 @@ var compilerOptions = require('../babel-options');
 var assign = Object.assign || require('object.assign');
 var notify = require('gulp-notify');
 var exec = require('child_process').exec;
+var htmlmin = require('gulp-htmlmin');
 
 // transpiles changed es6 files to SystemJS format
 // the plumber() call prevents 'pipe breaking' caused
@@ -28,6 +29,7 @@ gulp.task('build-system', function() {
 gulp.task('build-html', function() {
   return gulp.src(paths.html)
     .pipe(changed(paths.output, {extension: '.html'}))
+    .pipe(htmlmin({collapseWhitespace: true}))
     .pipe(gulp.dest(paths.output));
 });
 

--- a/skeleton-esnext-aspnetcore/src/skeleton/package.json
+++ b/skeleton-esnext-aspnetcore/src/skeleton/package.json
@@ -27,6 +27,7 @@
     "gulp-concat": "2.6.0",
     "gulp-cssmin": "0.1.7",
     "gulp-eslint": "^2.0.0",
+    "gulp-htmlmin": "^2.0.0",
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.1.0",
     "gulp-protractor": "2.4.0",

--- a/skeleton-esnext/build/tasks/build.js
+++ b/skeleton-esnext/build/tasks/build.js
@@ -9,6 +9,7 @@ var compilerOptions = require('../babel-options');
 var assign = Object.assign || require('object.assign');
 var notify = require('gulp-notify');
 var browserSync = require('browser-sync');
+var htmlmin = require('gulp-htmlmin');
 
 // transpiles changed es6 files to SystemJS format
 // the plumber() call prevents 'pipe breaking' caused
@@ -28,6 +29,7 @@ gulp.task('build-system', function() {
 gulp.task('build-html', function() {
   return gulp.src(paths.html)
     .pipe(changed(paths.output, {extension: '.html'}))
+    .pipe(htmlmin({collapseWhitespace: true}))
     .pipe(gulp.dest(paths.output));
 });
 

--- a/skeleton-esnext/package.json
+++ b/skeleton-esnext/package.json
@@ -44,6 +44,7 @@
     "gulp-bump": "^2.1.0",
     "gulp-changed": "^1.3.0",
     "gulp-eslint": "^2.0.0",
+    "gulp-htmlmin": "^2.0.0",
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.1.0",
     "gulp-protractor": "2.4.0",

--- a/skeleton-typescript-aspnetcore/src/skeleton/build/tasks/build.js
+++ b/skeleton-typescript-aspnetcore/src/skeleton/build/tasks/build.js
@@ -8,6 +8,7 @@ var assign = Object.assign || require('object.assign');
 var notify = require('gulp-notify');
 var typescript = require('gulp-typescript');
 var exec = require('child_process').exec;
+var htmlmin = require('gulp-htmlmin');
 
 // transpiles changed es6 files to SystemJS format
 // the plumber() call prevents 'pipe breaking' caused
@@ -33,6 +34,7 @@ gulp.task('build-system', function() {
 gulp.task('build-html', function() {
   return gulp.src(paths.html)
     .pipe(changed(paths.output, {extension: '.html'}))
+    .pipe(htmlmin({collapseWhitespace: true}))
     .pipe(gulp.dest(paths.output));
 });
 

--- a/skeleton-typescript-aspnetcore/src/skeleton/package.json
+++ b/skeleton-typescript-aspnetcore/src/skeleton/package.json
@@ -14,6 +14,7 @@
     "gulp-changed": "^1.3.0",
     "gulp-concat": "2.6.0",
     "gulp-cssmin": "0.1.7",
+    "gulp-htmlmin": "^2.0.0",
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.1.0",
     "gulp-protractor": "^2.4.0",

--- a/skeleton-typescript/build/tasks/build.js
+++ b/skeleton-typescript/build/tasks/build.js
@@ -8,6 +8,7 @@ var assign = Object.assign || require('object.assign');
 var notify = require('gulp-notify');
 var browserSync = require('browser-sync');
 var typescript = require('gulp-typescript');
+var htmlmin = require('gulp-htmlmin');
 
 // transpiles changed es6 files to SystemJS format
 // the plumber() call prevents 'pipe breaking' caused
@@ -33,6 +34,7 @@ gulp.task('build-system', function() {
 gulp.task('build-html', function() {
   return gulp.src(paths.html)
     .pipe(changed(paths.output, {extension: '.html'}))
+    .pipe(htmlmin({collapseWhitespace: true}))
     .pipe(gulp.dest(paths.output));
 });
 

--- a/skeleton-typescript/package.json
+++ b/skeleton-typescript/package.json
@@ -35,6 +35,7 @@
     "gulp": "^3.9.1",
     "gulp-bump": "^2.1.0",
     "gulp-changed": "^1.3.0",
+    "gulp-htmlmin": "^2.0.0",
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.1.0",
     "gulp-protractor": "2.4.0",


### PR DESCRIPTION
Fixes #340 by minifying the HTML on build to prevent developers from
editing the src.