### PR TITLE
fix(main): load bootstrap's javascript code

### DIFF
--- a/skeleton-esnext-webpack/src/main.js
+++ b/skeleton-esnext-webpack/src/main.js
@@ -1,4 +1,5 @@
 import {bootstrap} from 'aurelia-bootstrapper-webpack';
+import 'bootstrap';
 
 bootstrap(async (aurelia) => {
   aurelia.use

--- a/skeleton-typescript-webpack/src/main.ts
+++ b/skeleton-typescript-webpack/src/main.ts
@@ -1,5 +1,6 @@
 ﻿import {Aurelia} from 'aurelia-framework';
 import {bootstrap} from 'aurelia-bootstrapper-webpack';
+import 'bootstrap';
 
 bootstrap(async (aurelia: Aurelia) => {
   aurelia.use


### PR DESCRIPTION
Not sure when this line got removed from the webpack skeletons, but without it, the navbar won't function on a narrow/mobile screen.