### PR TITLE
Fix path when using PushState and route root of '/'

### DIFF
--- a/skeleton-typescript-aspnetcore/src/skeleton/views/home/Index.cshtml
+++ b/skeleton-typescript-aspnetcore/src/skeleton/views/home/Index.cshtml
@@ -10,9 +10,9 @@
     <!-- Windows 10 Anniversary Update on 2 August 2016. Once that update has pushed out, you may    -->
     <!-- consider removing bluebird from your project and simply using native promises if you do     -->
     <!-- not need to support Internet Explorer.                                                      -->
-    <script src="jspm_packages/npm/bluebird@3.4.1/js/browser/bluebird.min.js"></script> 
-    <script src="jspm_packages/system.js"></script>
-    <script src="config.js"></script>
+    <script src="/jspm_packages/npm/bluebird@3.4.1/js/browser/bluebird.min.js"></script> 
+    <script src="/jspm_packages/system.js"></script>
+    <script src="/config.js"></script>
     
     <script>
         System.import('aurelia-bootstrapper');


### PR DESCRIPTION
Using PushState with some subpaths like

/path1/path2/path3 

When running the app did not found the .js files (in the Layout.cshtml already uses / at the start of the file)