### PR TITLE
Fix packages paths when using PushState and route root of '/'

### DIFF
--- a/skeleton-typescript-aspnetcore/src/skeleton/wwwroot/config.js
+++ b/skeleton-typescript-aspnetcore/src/skeleton/wwwroot/config.js
@@ -2,9 +2,9 @@ System.config({
   defaultJSExtensions: true,
   transpiler: false,
   paths: {
-    "*": "dist/*",
-    "github:*": "jspm_packages/github/*",
-    "npm:*": "jspm_packages/npm/*"
+    "*": "/dist/*",
+    "github:*": "/jspm_packages/github/*",
+    "npm:*": "/jspm_packages/npm/*"
   },
 
   map: {


### PR DESCRIPTION
Using PushState with some subpaths like

/path1/path2/path3

When running the app did not found the .js files (in the Layout.cshtml already uses / at the start of the file)

PS: this PR completes the fix with: #633