### PR TITLE
chore(electron): disable electron node integration to fix jquery

### DIFF
--- a/skeleton-esnext/index.js
+++ b/skeleton-esnext/index.js
@@ -18,7 +18,14 @@ app.on('window-all-closed', () => {
 app.on('ready', () => {
   mainWindow = new BrowserWindow({
     width: 800,
-    height: 600
+    height: 600,
+    // Note: The following line turns off Node integration to allow
+    // jQuery to work properly. If you need Node integration, please
+    // see the Electron FAQ for how to enable this:
+    // http://electron.atom.io/docs/faq/
+    webPreferences: {
+      nodeIntegration: false
+    }
   });
 
   mainWindow.loadURL(`file://${__dirname}/index.html`);

--- a/skeleton-typescript/index.js
+++ b/skeleton-typescript/index.js
@@ -18,14 +18,21 @@ app.on('window-all-closed', () => {
 app.on('ready', () => {
   mainWindow = new BrowserWindow({
     width: 800,
-    height: 600
+    height: 600,
+    // Note: The following line turns off Node integration to allow 
+    // jQuery to work properly. If you need Node integration, please
+    // see the Electron FAQ for how to enable this:
+    // http://electron.atom.io/docs/faq/
+    webPreferences: {
+      nodeIntegration: false
+    }
   });
 
   mainWindow.loadURL(`file://${__dirname}/index.html`);
   mainWindow.webContents.on('did-finish-load', () => {
     mainWindow.setTitle(app.getName());
   });
-  
+
   mainWindow.on('closed', () => {
     mainWindow = null;
   });


### PR DESCRIPTION
I'm going to file a bug with @guybedford to see if he can do something about this on the JSPM/SystemJS side. Left a link showing how to re-enable node integration, but I didn't want to muddy up `index.html` with code that was unnecessary for everyone except Electron users.  They can follow the instructions in the Electron FAQ if they want to.

Fixes #674 
