### PR TITLE
Update README.md to add packaging instructions

### DIFF
--- a/skeleton-esnext/README.md
+++ b/skeleton-esnext/README.md
@@ -103,6 +103,29 @@ To run the app under [Electron](http://electron.atom.io), follow these steps.
    electron .
 ```
 
+## Packaging The App Using Electron-Packager
+
+>**Note:** The electron-packager package relies on `"main"` in package.json to know which JS file to use to start the application. To make this work with electron-packager change this line in package.json from `"main": "dist/main.js",` to `"main": "index.js",`
+
+1. Follow steps 1-6 in the previous section (Running The App under Electron).
+
+2. Install electron-packager
+
+  ```shell
+  npm install electron-packager -g
+  ```
+  
+3. Run the command:
+
+  ```shell
+  electron-packager <sourcedir> <appname> --platform=<platform> --arch=<arch> --version <electron version #> [optional flags...]
+  ```
+Include the `--asar` option to create an [asar archive](http://electron.atom.io/docs/tutorial/application-packaging/) from your app.
+
+By default, electron-packager will place the packaged app in a folder under the source folder with the naming convention of `<appname>-<platform>-<arch>`.
+
+See the [electron-packager](https://github.com/electron-userland/electron-packager) readme for more details on options.
+
 
 ## Bundling
 Bundling is performed by [Aurelia Bundler](http://github.com/aurelia/bundler). A gulp task is already configured for that. Use the following command to bundle the app:

--- a/skeleton-typescript/README.md
+++ b/skeleton-typescript/README.md
@@ -103,6 +103,29 @@ To run the app under [Electron](http://electron.atom.io), follow these steps.
    electron .
 ```
 
+## Packaging The App Using Electron-Packager
+
+>**Note:** The electron-packager package relies on `"main"` in package.json to know which JS file to use to start the application. To make this work with electron-packager change this line in package.json from `"main": "dist/main.js",` to `"main": "index.js",`
+
+1. Follow steps 1-6 in the previous section (Running The App under Electron).
+
+2. Install electron-packager
+
+  ```shell
+  npm install electron-packager -g
+  ```
+  
+3. Run the command:
+
+  ```shell
+  electron-packager <sourcedir> <appname> --platform=<platform> --arch=<arch> --version <electron version #> [optional flags...]
+  ```
+Include the `--asar` option to create an [asar archive](http://electron.atom.io/docs/tutorial/application-packaging/) from your app.
+
+By default, electron-packager will place the packaged app in a folder under the source folder with the naming convention of `<appname>-<platform>-<arch>`.
+
+See the [electron-packager](https://github.com/electron-userland/electron-packager) readme for more details on options.
+
 
 ## Bundling
 Bundling is performed by [Aurelia Bundler](http://github.com/aurelia/bundler). A gulp task is already configured for that. Use the following command to bundle the app:


### PR DESCRIPTION
Include packaging instructions using electron-packager.

Add Note that "main" in package.json needs to be changed to 'index.js' for packaging to succeed.

NOTE: this README.md update should also be applied to the skeleton-esnext README, since both appear to have the same instructions for running within Electron.