### PR TITLE
fix(index): specify utf-8 as the charset [esnext]

### DIFF
--- a/skeleton-esnext/index.html
+++ b/skeleton-esnext/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>Aurelia</title>
     <!--The FontAwesome version is locked at 4.6.3 in the package.json file to keep this from breaking.-->
     <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.6.3/css/font-awesome.min.css">


### PR DESCRIPTION
Follow best practice to explicitly declare a charset.

Relates to #642