### PR TITLE
fix(index): specify utf-8 as the charset [typescript]

### DIFF
--- a/skeleton-typescript/index.html
+++ b/skeleton-typescript/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>Aurelia</title>
     <!--The FontAwesome version is locked at 4.6.3 in the package.json file to keep this from breaking.-->
     <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.6.3/css/font-awesome.min.css">
@@ -13,14 +14,14 @@
       <div class="message">Aurelia Navigation Skeleton</div>
       <i class="fa fa-spinner fa-spin"></i>
     </div>
-    
+
     <!-- The bluebird version is locked at 4.6.3 in the package.json file to keep this from breaking -->
     <!-- We include bluebird to bypass Edge's very slow Native Promise implementation. The Edge team -->
     <!-- has fixed the issues with their implementation with these fixes being distributed with the  -->
     <!-- Windows 10 Anniversary Update on 2 August 2016. Once that update has pushed out, you may    -->
     <!-- consider removing bluebird from your project and simply using native promises if you do     -->
     <!-- not need to support Internet Explorer.                                                      -->
-    <script src="jspm_packages/npm/bluebird@3.4.1/js/browser/bluebird.min.js"></script> 
+    <script src="jspm_packages/npm/bluebird@3.4.1/js/browser/bluebird.min.js"></script>
     <script src="jspm_packages/system.js"></script>
     <script src="config.js"></script>
     <script>


### PR DESCRIPTION
Follow best practice to explicitly declare a charset.

Relates to #642