### PR TITLE
fix(index): specify utf-8 as the charset [typescript-webpack]

### DIFF
--- a/skeleton-typescript-webpack/index.html
+++ b/skeleton-typescript-webpack/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title><%- webpackConfig.metadata.title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <base href="<%- webpackConfig.metadata.baseUrl %>">


### PR DESCRIPTION
Follow best practice to explicitly declare a charset.

Relates to #642