### PR TITLE
fix(code splitting): Fix error “Multiple assets emit”

### DIFF
--- a/skeleton-typescript-webpack/webpack.config.js
+++ b/skeleton-typescript-webpack/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = ({production, server, extractCss, coverage} = {}) => ({
     publicPath: baseUrl,
     filename: production ? '[name].[chunkhash].bundle.js' : '[name].[hash].bundle.js',
     sourceMapFilename: production ? '[name].[chunkhash].bundle.map' : '[name].[hash].bundle.map',
-    chunkFilename: production ? '[chunkhash].chunk.js' : '[hash].chunk.js',
+    chunkFilename: production ? '[name].[chunkhash].chunk.js' : '[name].[hash].chunk.js',
   },
   devServer: {
     contentBase: baseUrl,


### PR DESCRIPTION
Fixes error “Conflict: Multiple assets emit to the same filename f952101eaf243f0f36fb.chunk.js” by using chunk name in file name in Webpack config.

## Error without this fix:
```
ERROR in chunk users
f952101eaf243f0f36fb.chunk.js
Conflict: Multiple assets emit to the same filename f952101eaf243f0f36fb.chunk.js

ERROR in chunk welcome
f952101eaf243f0f36fb.chunk.js
Conflict: Multiple assets emit to the same filename f952101eaf243f0f36fb.chunk.js

ERROR in chunk 3
f952101eaf243f0f36fb.chunk.js
Conflict: Multiple assets emit to the same filename f952101eaf243f0f36fb.chunk.js
```
## See reference: 
https://github.com/jods4/aurelia-webpack-build/tree/master/demos/03-Code_splits
Using `[name].js` in Webpack config for chunkFilename to solve the above error.

## Thoughts
Only using `[hash].js` will conflict as hash isn't unique. `[chunkhash]` on the other hand is unique but I think it's a good idea to be consistent and prepend the name to chunk files.
So at the end I think this patter is good `[name].[hash].chunk.js`.

## Help how to enable code splitting
Add second parameter to `PLATFROM.moduleName` like:
```javascript
{ route: ['', 'welcome'], name: 'welcome',      moduleId: PLATFORM.moduleName('./welcome', 'weclome'),      nav: true, title: 'Welcome' },
{ route: 'users',         name: 'users',        moduleId: PLATFORM.moduleName('./users', 'users'),        nav: true, title: 'Github Users' },
{ route: 'child-router',  name: 'child-router', moduleId: PLATFORM.moduleName('./child-router', 'child-router'), nav: true, title: 'Child Router' },
```

## Additional info:
~~Issue~~ with child-router: https://github.com/jods4/aurelia-webpack-build/issues/34
Article/tutorial: https://ilikekillnerds.com/2017/03/code-splitting-aurelia-webpack-applications/