### PR TITLE
chore(tests): lock version of typescript

### DIFF
--- a/skeleton-typescript/package.json
+++ b/skeleton-typescript/package.json
@@ -42,7 +42,7 @@
     "gulp-protractor": "3.0.0",
     "gulp-sourcemaps": "^2.2.0",
     "gulp-tslint": "^6.1.3",
-    "gulp-typescript": "^3.1.2",
+    "gulp-typescript": "^3.1.6",
     "isparta": "^4.0.0",
     "jasmine-core": "^2.5.2",
     "jspm": "^0.16.47",
@@ -56,7 +56,7 @@
     "run-sequence": "^1.2.2",
     "systemjs": "0.19.40",
     "tslint": "^3.15.1",
-    "typescript": "^2.2.1",
+    "typescript": "2.2.1",
     "typings": "^2.0.0",
     "vinyl-paths": "^2.1.0",
     "yargs": "^6.3.0"
@@ -85,5 +85,5 @@
     },
     "devDependencies": {}
   },
-  "dependencies": { }
+  "dependencies": {}
 }


### PR DESCRIPTION
Current configuration not compatible with latest TypeScript.  Lock it at
2.2.1 on a known working version and update next.

Fixes #823 #281 #