### PR TITLE
fix(webpack-ssr): missing env for ssr prod build

### DIFF
--- a/skeleton-typescript-webpack-ssr/package-scripts.js
+++ b/skeleton-typescript-webpack-ssr/package-scripts.js
@@ -61,7 +61,7 @@ module.exports = {
           ),
           ssr: series(
             'nps webpack.build.before',
-            'webpack --progress -p --env.production --env.extractCss',
+            'webpack --progress -p --env.production --env.extractCss --env.ssr',
             'webpack --config webpack.server.config.js --progress -p --env.production --env.extractCss'
           )
         }

--- a/skeleton-typescript-webpack-ssr/package.json
+++ b/skeleton-typescript-webpack-ssr/package.json
@@ -13,7 +13,8 @@
     "test": "nps test",
     "start": "nps",
     "watch": "nps webpack.server.ssr.watch",
-    "server": "nps webpack.server.ssr.start"
+    "server": "nps webpack.server.ssr.start",
+    "build:ssr": "nps webpack.build.production.ssr"
   },
   "engines": {
     "node": ">= 6.0.0"


### PR DESCRIPTION
The production build task was missing the `ssr` environment variable, meaning the condition for building the `index.ssr.html` file in `webpack.config.js` was not being met.