### PR TITLE
fix(path-resolution): move TsConfigPathsPlugin to resolve plugins

### DIFF
--- a/skeleton-typescript-webpack-ssr/webpack.config.js
+++ b/skeleton-typescript-webpack-ssr/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = ({production, server, extractCss, coverage, ssr} = {}) => ({
   resolve: {
     extensions: ['.ts', '.js'],
     modules: [srcDir, 'node_modules'],
+    plugins: [new TsConfigPathsPlugin()],
   },
   entry: {
     app: ['aurelia-bootstrapper'],
@@ -94,7 +95,6 @@ module.exports = ({production, server, extractCss, coverage, ssr} = {}) => ({
       'jQuery': 'jquery',
       'window.jQuery': 'jquery',
     }),
-    new TsConfigPathsPlugin(),
     new CheckerPlugin(),
     new HtmlWebpackPlugin({
       filename: ssr ? 'index.ssr.html' : 'index.html',

--- a/skeleton-typescript-webpack-ssr/webpack.server.config.js
+++ b/skeleton-typescript-webpack-ssr/webpack.server.config.js
@@ -35,6 +35,7 @@ module.exports = ({production, server, extractCss, coverage, ssr} = {}) => ({
   resolve: {
     extensions: ['.ts', '.js'],
     modules: [srcDir, 'node_modules'],
+    plugins: [new TsConfigPathsPlugin()],
   },
   entry: {
     server: './src/server-main'
@@ -107,7 +108,6 @@ module.exports = ({production, server, extractCss, coverage, ssr} = {}) => ({
       'jQuery': 'jquery',
       'window.jQuery': 'jquery',
     }),
-    new TsConfigPathsPlugin(),
     new CheckerPlugin(),
     new CopyWebpackPlugin([
       { from: 'static/favicon.ico', to: 'favicon.ico' },

--- a/skeleton-typescript-webpack/webpack.config.js
+++ b/skeleton-typescript-webpack/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = ({production, server, extractCss, coverage} = {}) => ({
   resolve: {
     extensions: ['.ts', '.js'],
     modules: [srcDir, 'node_modules'],
+    plugins: [new TsConfigPathsPlugin()],
   },
 
   devtool: production ? 'source-map' : 'cheap-module-eval-source-map',
@@ -99,7 +100,6 @@ module.exports = ({production, server, extractCss, coverage} = {}) => ({
       'jQuery': 'jquery',
       'window.jQuery': 'jquery',
     }),
-    new TsConfigPathsPlugin(),
     new CheckerPlugin(),
     new HtmlWebpackPlugin({
       template: 'index.ejs',


### PR DESCRIPTION
Initially the TsConfigPathsPlugin didn't work and to fix this I changed the configuration.
According to [awesome-typescript-loader](https://github.com/s-panferov/awesome-typescript-loader#advanced-path-resolution-in-typescript-20) the TsConfigPathsPlugin should be placed at 'resolve.plugins'.
