### PR TITLE
doc(main): remove example plugin configuration

### DIFF
--- a/skeleton-esnext-aspnetcore/src/skeleton/src/main.js
+++ b/skeleton-esnext-aspnetcore/src/skeleton/src/main.js
@@ -5,12 +5,5 @@ export function configure(aurelia) {
     .standardConfiguration()
     .developmentLogging();
 
-  //Uncomment the line below to enable animation.
-  //aurelia.use.plugin('aurelia-animator-css');
-  //if the css animator is enabled, add swap-order="after" to all router-view elements
-
-  //Anyone wanting to use HTMLImports to load views, will need to install the following plugin.
-  //aurelia.use.plugin('aurelia-html-import-template-loader')
-
   aurelia.start().then(() => aurelia.setRoot());
 }

--- a/skeleton-esnext-webpack/src/main.js
+++ b/skeleton-esnext-webpack/src/main.js
@@ -13,13 +13,6 @@ export async function configure(aurelia) {
     .standardConfiguration()
     .developmentLogging();
 
-  // Uncomment the line below to enable animation.
-  // aurelia.use.plugin(PLATFORM.moduleName('aurelia-animator-css'));
-  // if the css animator is enabled, add swap-order="after" to all router-view elements
-
-  // Anyone wanting to use HTMLImports to load views, will need to install the following plugin.
-  // aurelia.use.plugin(PLATFORM.moduleName('aurelia-html-import-template-loader'));
-
   await aurelia.start();
   await aurelia.setRoot(PLATFORM.moduleName('app'));
 }

--- a/skeleton-esnext/src/main.js
+++ b/skeleton-esnext/src/main.js
@@ -5,12 +5,5 @@ export function configure(aurelia) {
     .standardConfiguration()
     .developmentLogging();
 
-  //Uncomment the line below to enable animation.
-  //aurelia.use.plugin('aurelia-animator-css');
-  //if the css animator is enabled, add swap-order="after" to all router-view elements
-
-  //Anyone wanting to use HTMLImports to load views, will need to install the following plugin.
-  //aurelia.use.plugin('aurelia-html-import-template-loader')
-
   aurelia.start().then(() => aurelia.setRoot());
 }

--- a/skeleton-typescript-aspnetcore/src/skeleton/src/main.ts
+++ b/skeleton-typescript-aspnetcore/src/skeleton/src/main.ts
@@ -6,11 +6,5 @@ export function configure(aurelia: Aurelia) {
     .standardConfiguration()
     .developmentLogging();
 
-  // Uncomment the line below to enable animation.
-  // aurelia.use.plugin('aurelia-animator-css');
-
-  // Anyone wanting to use HTMLImports to load views, will need to install the following plugin.
-  // aurelia.use.plugin('aurelia-html-import-template-loader')
-
   aurelia.start().then(() => aurelia.setRoot());
 }

--- a/skeleton-typescript-webpack-ssr/src/main.ts
+++ b/skeleton-typescript-webpack-ssr/src/main.ts
@@ -10,13 +10,6 @@ export async function configure(aurelia: Aurelia) {
     .standardConfiguration()
     .developmentLogging();
 
-  // Uncomment the line below to enable animation.
-  // aurelia.use.plugin(PLATFORM.moduleName('aurelia-animator-css'));
-  // if the css animator is enabled, add swap-order="after" to all router-view elements
-
-  // Anyone wanting to use HTMLImports to load views, will need to install the following plugin.
-  // aurelia.use.plugin(PLATFORM.moduleName('aurelia-html-import-template-loader'));
-
   await aurelia.start();
   await aurelia.setRoot(PLATFORM.moduleName('app'));
 }

--- a/skeleton-typescript-webpack/src/main.ts
+++ b/skeleton-typescript-webpack/src/main.ts
@@ -15,13 +15,6 @@ export async function configure(aurelia: Aurelia) {
     .standardConfiguration()
     .developmentLogging();
 
-  // Uncomment the line below to enable animation.
-  // aurelia.use.plugin(PLATFORM.moduleName('aurelia-animator-css'));
-  // if the css animator is enabled, add swap-order="after" to all router-view elements
-
-  // Anyone wanting to use HTMLImports to load views, will need to install the following plugin.
-  // aurelia.use.plugin(PLATFORM.moduleName('aurelia-html-import-template-loader'));
-
   await aurelia.start();
   await aurelia.setRoot(PLATFORM.moduleName('app'));
 }

--- a/skeleton-typescript/src/main.ts
+++ b/skeleton-typescript/src/main.ts
@@ -6,11 +6,5 @@ export function configure(aurelia: Aurelia) {
     .standardConfiguration()
     .developmentLogging();
 
-  // Uncomment the line below to enable animation.
-  // aurelia.use.plugin('aurelia-animator-css');
-
-  // Anyone wanting to use HTMLImports to load views, will need to install the following plugin.
-  // aurelia.use.plugin('aurelia-html-import-template-loader')
-
   aurelia.start().then(() => aurelia.setRoot());
 }


### PR DESCRIPTION
Fixes #787.

Just to get the ball rolling on this, I thought I'd go with the simple fix of just removing the confusing comments.