### PR TITLE
Correctly exclude spec/test files from coverage reporting

### DIFF
--- a/skeleton-typescript-webpack-ssr/webpack.config.js
+++ b/skeleton-typescript-webpack-ssr/webpack.config.js
@@ -81,7 +81,7 @@ module.exports = ({production, server, extractCss, coverage, ssr} = {}) => ({
       { test: /\.(ttf|eot|svg|otf)(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'file-loader' },
       ...when(coverage, {
         test: /\.[jt]s$/i, loader: 'istanbul-instrumenter-loader',
-        include: srcDir, exclude: [/\.{spec,test}\.[jt]s$/i],
+        include: srcDir, exclude: [/\.(spec|test)\.[jt]s$/i],
         enforce: 'post', options: { esModules: true },
       })
     ]
@@ -103,7 +103,7 @@ module.exports = ({production, server, extractCss, coverage, ssr} = {}) => ({
       minify: production ? {
         // we don't want to remove comments as they are used as a placeholder
         // for Aurelia SSR
-        removeComments: false, 
+        removeComments: false,
         collapseWhitespace: true
       } : undefined,
       metadata: {

--- a/skeleton-typescript-webpack-ssr/webpack.server.config.js
+++ b/skeleton-typescript-webpack-ssr/webpack.server.config.js
@@ -91,7 +91,7 @@ module.exports = ({production, server, extractCss, coverage, ssr} = {}) => ({
       { test: /\.(ttf|eot|svg|otf)(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'file-loader' },
       ...when(coverage, {
         test: /\.[jt]s$/i, loader: 'istanbul-instrumenter-loader',
-        include: srcDir, exclude: [/\.{spec,test}\.[jt]s$/i],
+        include: srcDir, exclude: [/\.(spec|test)\.[jt]s$/i],
         enforce: 'post', options: { esModules: true },
       })
     ]

--- a/skeleton-typescript-webpack/webpack.config.js
+++ b/skeleton-typescript-webpack/webpack.config.js
@@ -86,7 +86,7 @@ module.exports = ({production, server, extractCss, coverage} = {}) => ({
       { test: /\.(ttf|eot|svg|otf)(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'file-loader' },
       ...when(coverage, {
         test: /\.[jt]s$/i, loader: 'istanbul-instrumenter-loader',
-        include: srcDir, exclude: [/\.{spec,test}\.[jt]s$/i],
+        include: srcDir, exclude: [/\.(spec|test)\.[jt]s$/i],
         enforce: 'post', options: { esModules: true },
       })
     ]


### PR DESCRIPTION
The string {spec,test} didn't match filenames containing spec or test, as was clearly intended.
This causes coverage reports to include these files.

Before: 
![image](https://user-images.githubusercontent.com/1052079/50267848-bde70300-047c-11e9-9e94-e59d874cd474.png)

After:
![image](https://user-images.githubusercontent.com/1052079/50267861-c8a19800-047c-11e9-9ae3-b5a19005b98a.png)
